### PR TITLE
Fix summary access check and add tests

### DIFF
--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryService.java
@@ -22,9 +22,10 @@ public class ExpenseSummaryService {
     private final ExpenseSummaryMapper mapper;
 
     public List<ExpenseSummaryResponseDTO> getAllSummaries(User user, UUID userId) {
-        if (user.getId() != userId) throw new UnauthorizedException("User does not have permission to view other user's summaries.");
+        if (!user.getId().equals(userId))
+            throw new UnauthorizedException("User does not have permission to view other user's summaries.");
 
-        return summaryRepository.findByUserId(user.getId()).stream()
+        return summaryRepository.findByUserId(userId).stream()
                 .map(mapper::toResponseDto)
                 .toList();
     }

--- a/server/src/test/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryServiceTests.java
+++ b/server/src/test/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryServiceTests.java
@@ -1,0 +1,54 @@
+package com.credit_card_bill_tracker.backend.expensesummary;
+
+import com.credit_card_bill_tracker.backend.common.errors.UnauthorizedException;
+import com.credit_card_bill_tracker.backend.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ExpenseSummaryServiceTests {
+
+    private ExpenseSummaryRepository repository;
+    private ExpenseSummaryMapper mapper;
+    private ExpenseSummaryService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ExpenseSummaryRepository.class);
+        mapper = mock(ExpenseSummaryMapper.class);
+        service = new ExpenseSummaryService(repository, mapper);
+    }
+
+    @Test
+    void userCannotAccessOtherUsersSummaries() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        UUID otherId = UUID.randomUUID();
+
+        assertThrows(UnauthorizedException.class, () -> service.getAllSummaries(user, otherId));
+        verify(repository, never()).findByUserId(any());
+    }
+
+    @Test
+    void returnsMappedSummariesForUser() {
+        UUID id = UUID.randomUUID();
+        User user = new User();
+        user.setId(id);
+
+        ExpenseSummary summary = new ExpenseSummary();
+        ExpenseSummaryResponseDTO dto = new ExpenseSummaryResponseDTO();
+
+        when(repository.findByUserId(id)).thenReturn(List.of(summary));
+        when(mapper.toResponseDto(summary)).thenReturn(dto);
+
+        List<ExpenseSummaryResponseDTO> result = service.getAllSummaries(user, id);
+
+        assertEquals(List.of(dto), result);
+        verify(repository).findByUserId(id);
+    }
+}


### PR DESCRIPTION
## Summary
- fix user check in `ExpenseSummaryService#getAllSummaries`
- query summaries with the requested user id
- add unit tests for summary access and retrieval

## Testing
- `./mvnw test` *(fails: wget failed to fetch from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_685e38e201ac8323b45d315387313f22