### PR TITLE
Switch to enum for summary target type

### DIFF
--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleService.java
@@ -2,6 +2,7 @@ package com.credit_card_bill_tracker.backend.billingcycle;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
 import com.credit_card_bill_tracker.backend.billpayment.*;
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
 import com.credit_card_bill_tracker.backend.common.errors.ResourceNotFoundException;
 import com.credit_card_bill_tracker.backend.creditcard.CreditCard;
 import com.credit_card_bill_tracker.backend.user.User;
@@ -56,7 +57,7 @@ public class BillingCycleService {
             db.setAmount(suggestion.getAmount());
             db.setBillingCycle(savedCycle);
 
-            if ("card".equals(suggestion.getToType())) {
+            if (suggestion.getToType() == TargetType.CARD) {
                 CreditCard toCard = new CreditCard();
                 toCard.setId(suggestion.getTo());
                 db.setToCard(toCard);

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillSuggestionDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillSuggestionDTO.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
 
 @Data
 @NoArgsConstructor
@@ -12,5 +13,5 @@ public class BillSuggestionDTO {
     private UUID from;
     private UUID to;
     private double amount;
-    private String toType; //"card" or "account"
+    private TargetType toType;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummary.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummary.java
@@ -4,6 +4,7 @@ import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
 import com.credit_card_bill_tracker.backend.common.BaseEntity;
 import com.credit_card_bill_tracker.backend.common.errors.BadRequestException;
 import com.credit_card_bill_tracker.backend.user.User;
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,8 +29,9 @@ public class ExpenseSummary extends BaseEntity {
     @Column(name = "to_id", nullable = false)
     private UUID toId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "to_type", nullable = false)
-    private String toType; // "card" or "account"
+    private TargetType toType;
 
     @Column(nullable = false)
     private double totalExpense = 0.0;
@@ -60,8 +62,8 @@ public class ExpenseSummary extends BaseEntity {
     @PrePersist
     @PreUpdate
     private void validateToFields() {
-        if (!"card".equals(toType) && !"account".equals(toType)) {
-            throw new BadRequestException("toType must be 'card' or 'account'", List.of("Expense Summary: " + this.getId()));
+        if (toType == null) {
+            throw new BadRequestException("toType cannot be null", List.of("Expense Summary: " + this.getId()));
         }
         if (toId == null) {
             throw new BadRequestException("toId cannot be null", List.of("Expense Summary: " + this.getId()));

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryRepository.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryRepository.java
@@ -7,8 +7,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
+
 @Repository
 public interface ExpenseSummaryRepository extends BaseRepository<ExpenseSummary, UUID> {
     List<ExpenseSummary> findByUserId(UUID userId);
-    Optional<ExpenseSummary> findByUserIdAndFromAccountIdAndToIdAndToType(UUID userId, UUID fromAccountId, UUID toId, String toType);
+    Optional<ExpenseSummary> findByUserIdAndFromAccountIdAndToIdAndToType(UUID userId, UUID fromAccountId, UUID toId, TargetType toType);
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryResponseDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryResponseDTO.java
@@ -4,12 +4,18 @@ import lombok.Data;
 
 import java.util.UUID;
 
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
+
+/**
+ * DTO representing aggregated expense information for an account-card pair.
+ */
+
 @Data
 public class ExpenseSummaryResponseDTO {
     private UUID id;
     private UUID fromAccountId;
     private UUID toId;
-    private String toType;
+    private TargetType toType;
     private double totalExpense;
     private double totalPaid;
     private double remaining;

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/ExpenseSummaryService.java
@@ -5,6 +5,7 @@ import com.credit_card_bill_tracker.backend.billpayment.BillPayment;
 import com.credit_card_bill_tracker.backend.common.errors.UnauthorizedException;
 import com.credit_card_bill_tracker.backend.creditcard.CreditCard;
 import com.credit_card_bill_tracker.backend.expense.Expense;
+import com.credit_card_bill_tracker.backend.expensesummary.TargetType;
 import com.credit_card_bill_tracker.backend.user.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -39,13 +40,13 @@ public class ExpenseSummaryService {
 
         for (BankAccount from : fromAccounts) {
             ExpenseSummary summary = summaryRepository
-                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), from.getId(), toCard.getId(), "card")
+                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), from.getId(), toCard.getId(), TargetType.CARD)
                     .orElseGet(() -> {
                         ExpenseSummary s = new ExpenseSummary();
                         s.setUser(user);
                         s.setFromAccount(from);
                         s.setToId(toCard.getId());
-                        s.setToType("card");
+                        s.setToType(TargetType.CARD);
                         return s;
                     });
             summary.updateExpense(splitAmount, isAdding);
@@ -64,13 +65,13 @@ public class ExpenseSummaryService {
         if (payment.getToCard() != null) {
             UUID toCardId = payment.getToCard().getId();
             ExpenseSummary summary = summaryRepository
-                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), payment.getFromAccount().getId(), toCardId, "card")
+                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), payment.getFromAccount().getId(), toCardId, TargetType.CARD)
                     .orElseGet(() -> {
                         ExpenseSummary s = new ExpenseSummary();
                         s.setUser(user);
                         s.setFromAccount(payment.getFromAccount());
                         s.setToId(toCardId);
-                        s.setToType("card");
+                        s.setToType(TargetType.CARD);
                         return s;
                     });
             summary.updatePayment(delta, isAdding);
@@ -80,13 +81,13 @@ public class ExpenseSummaryService {
             // special case: paying to another bank account — create a synthetic summary with a virtual card ID
             UUID ToAccountId = payment.getToAccount().getId();
             ExpenseSummary summary = summaryRepository
-                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), payment.getFromAccount().getId(), ToAccountId, "account")
+                    .findByUserIdAndFromAccountIdAndToIdAndToType(user.getId(), payment.getFromAccount().getId(), ToAccountId, TargetType.ACCOUNT)
                     .orElseGet(() -> {
                         ExpenseSummary s = new ExpenseSummary();
                         s.setUser(user);
                         s.setFromAccount(payment.getFromAccount());
                         s.setToId(ToAccountId);
-                        s.setToType("account");
+                        s.setToType(TargetType.ACCOUNT);
                         return s;
                     });
             summary.updatePayment(delta, isAdding);

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/TargetType.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expensesummary/TargetType.java
@@ -1,0 +1,6 @@
+package com.credit_card_bill_tracker.backend.expensesummary;
+
+public enum TargetType {
+    CARD,
+    ACCOUNT
+}


### PR DESCRIPTION
## Summary
- create `TargetType` enum for ExpenseSummary targets
- store enum in `ExpenseSummary` and related DTOs
- adapt repository and services to use the enum

## Testing
- `mvnw test` *(fails: unable to fetch maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e4b8f17208323a891727b5562d01f