### PR TITLE
Implement new bill optimization logic

### DIFF
--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillOptimizerService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillOptimizerService.java
@@ -17,20 +17,82 @@ public class BillOptimizerService {
     public List<BillSuggestionDTO> computeBillSuggestions(User user) {
         List<ExpenseSummary> summaries = expenseSummaryRepository.findByUserId(user.getId());
 
-        List<BillSuggestionDTO> suggestions = new ArrayList<>();
+        // Track the net remaining amount for every account and card.
+        // Only positive remaining values represent unpaid balances. Negative
+        // values mean the card was overpaid and should not influence other
+        // accounts' suggestions.
+        Map<UUID, Double> remainingMap = new LinkedHashMap<>();
+        Map<UUID, String> typeMap = new HashMap<>();
 
         for (ExpenseSummary summary : summaries) {
             double remaining = summary.getRemaining();
-            if (remaining > 0) {
-                BillSuggestionDTO suggestion = new BillSuggestionDTO();
-                suggestion.setFrom(summary.getFromAccount().getId());
-                suggestion.setAmount(remaining);
-                suggestion.setTo(summary.getToId());
-                suggestion.setToType(summary.getToType());
-                suggestions.add(suggestion);
+            if (remaining <= 0) {
+                // The from account already paid more than required. This
+                // prepayment should be used only for future expenses on the
+                // same card/account so it does not participate in the
+                // optimisation step.
+                continue;
+            }
+
+            UUID fromId = summary.getFromAccount().getId();
+            remainingMap.merge(fromId, remaining, Double::sum);
+            typeMap.putIfAbsent(fromId, "account");
+
+            UUID toId = summary.getToId();
+            remainingMap.merge(toId, -remaining, Double::sum);
+            typeMap.putIfAbsent(toId, summary.getToType());
+        }
+
+        // Separate surpluses and deficits
+        Map<UUID, Double> surpluses = new LinkedHashMap<>();
+        Map<UUID, DeficitInfo> deficits = new LinkedHashMap<>();
+
+        for (Map.Entry<UUID, Double> entry : remainingMap.entrySet()) {
+            double amt = entry.getValue();
+            if (amt > 0) {
+                if ("account".equals(typeMap.get(entry.getKey()))) {
+                    surpluses.put(entry.getKey(), amt);
+                }
+            } else if (amt < 0) {
+                deficits.put(entry.getKey(), new DeficitInfo(-amt, typeMap.get(entry.getKey())));
             }
         }
-//TODO need to verify correctness and optimisation of this service method
+
+        List<BillSuggestionDTO> suggestions = new ArrayList<>();
+
+        for (Map.Entry<UUID, Double> surplusEntry : surpluses.entrySet()) {
+            double available = surplusEntry.getValue();
+            if (available <= 0) continue;
+
+            for (Map.Entry<UUID, DeficitInfo> deficitEntry : deficits.entrySet()) {
+                DeficitInfo info = deficitEntry.getValue();
+                if (info.amount <= 0) continue;
+
+                double payment = Math.min(available, info.amount);
+                suggestions.add(new BillSuggestionDTO(
+                        surplusEntry.getKey(),
+                        deficitEntry.getKey(),
+                        payment,
+                        info.type
+                ));
+
+                available -= payment;
+                info.amount -= payment;
+
+                if (available <= 0) break;
+            }
+        }
+
         return suggestions;
+    }
+
+    private static class DeficitInfo {
+        double amount; // always positive
+        String type;
+
+        DeficitInfo(double amount, String type) {
+            this.amount = amount;
+            this.type = type;
+        }
     }
 }

--- a/server/src/test/java/com/credit_card_bill_tracker/backend/billpayment/BillOptimizerServiceTests.java
+++ b/server/src/test/java/com/credit_card_bill_tracker/backend/billpayment/BillOptimizerServiceTests.java
@@ -1,0 +1,135 @@
+package com.credit_card_bill_tracker.backend.billpayment;
+
+import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
+import com.credit_card_bill_tracker.backend.creditcard.CreditCard;
+import com.credit_card_bill_tracker.backend.expensesummary.ExpenseSummary;
+import com.credit_card_bill_tracker.backend.expensesummary.ExpenseSummaryRepository;
+import com.credit_card_bill_tracker.backend.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class BillOptimizerServiceTests {
+
+    private ExpenseSummaryRepository repository;
+    private BillOptimizerService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ExpenseSummaryRepository.class);
+        service = new BillOptimizerService(repository);
+    }
+
+    private ExpenseSummary buildSummary(User user, BankAccount from, UUID toId, String toType, double amount) {
+        ExpenseSummary s = new ExpenseSummary();
+        s.setUser(user);
+        s.setFromAccount(from);
+        s.setToId(toId);
+        s.setToType(toType);
+        s.setTotalExpense(amount);
+        s.setTotalPaid(0);
+        return s;
+    }
+
+    @Test
+    void singleAccountSingleCard() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+
+        BankAccount bank = new BankAccount();
+        bank.setId(UUID.randomUUID());
+        CreditCard card = new CreditCard();
+        card.setId(UUID.randomUUID());
+
+        ExpenseSummary summary = buildSummary(user, bank, card.getId(), "card", 100);
+
+        when(repository.findByUserId(user.getId())).thenReturn(List.of(summary));
+
+        List<BillSuggestionDTO> result = service.computeBillSuggestions(user);
+
+        assertEquals(1, result.size());
+        BillSuggestionDTO dto = result.get(0);
+        assertEquals(bank.getId(), dto.getFrom());
+        assertEquals(card.getId(), dto.getTo());
+        assertEquals(100, dto.getAmount());
+        assertEquals("card", dto.getToType());
+    }
+
+    @Test
+    void indirectPaymentsAreOptimized() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+
+        BankAccount a = new BankAccount();
+        a.setId(UUID.randomUUID());
+        BankAccount b = new BankAccount();
+        b.setId(UUID.randomUUID());
+        CreditCard card = new CreditCard();
+        card.setId(UUID.randomUUID());
+
+        ExpenseSummary s1 = buildSummary(user, a, b.getId(), "account", 50);
+        ExpenseSummary s2 = buildSummary(user, b, card.getId(), "card", 100);
+
+        when(repository.findByUserId(user.getId())).thenReturn(List.of(s1, s2));
+
+        List<BillSuggestionDTO> result = service.computeBillSuggestions(user);
+
+        assertEquals(2, result.size());
+        // total amount to card should equal 100
+        double totalToCard = result.stream()
+                .filter(r -> r.getTo().equals(card.getId()))
+                .mapToDouble(BillSuggestionDTO::getAmount)
+                .sum();
+        assertEquals(100, totalToCard);
+    }
+
+    @Test
+    void overpaymentProducesNoSuggestions() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+
+        BankAccount bank = new BankAccount();
+        bank.setId(UUID.randomUUID());
+        CreditCard card = new CreditCard();
+        card.setId(UUID.randomUUID());
+
+        ExpenseSummary summary = buildSummary(user, bank, card.getId(), "card", -50);
+
+        when(repository.findByUserId(user.getId())).thenReturn(List.of(summary));
+
+        List<BillSuggestionDTO> result = service.computeBillSuggestions(user);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void overpaymentDoesNotReduceOthersBills() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+
+        BankAccount a = new BankAccount();
+        a.setId(UUID.randomUUID());
+        BankAccount b = new BankAccount();
+        b.setId(UUID.randomUUID());
+        CreditCard card = new CreditCard();
+        card.setId(UUID.randomUUID());
+
+        ExpenseSummary overpay = buildSummary(user, a, card.getId(), "card", -20);
+        ExpenseSummary due = buildSummary(user, b, card.getId(), "card", 30);
+
+        when(repository.findByUserId(user.getId())).thenReturn(List.of(overpay, due));
+
+        List<BillSuggestionDTO> result = service.computeBillSuggestions(user);
+
+        assertEquals(1, result.size());
+        BillSuggestionDTO dto = result.get(0);
+        assertEquals(b.getId(), dto.getFrom());
+        assertEquals(card.getId(), dto.getTo());
+        assertEquals(30, dto.getAmount());
+    }
+}


### PR DESCRIPTION
## Summary
- rework `BillOptimizerService` to compute balances per account/card
- use surpluses to pay off deficits directly
- ignore negative remaining amounts as prepaid credit
- add unit tests verifying overpayment handling

## Testing
- `./mvnw test -q` *(fails: unable to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e4b73d9848323b49fef4170993813