### PR TITLE
Switch JWT auth to HttpOnly cookie

### DIFF
--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/AuthController.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/AuthController.java
@@ -3,6 +3,9 @@ package com.credit_card_bill_tracker.backend.auth;
 import com.credit_card_bill_tracker.backend.common.ApiResponse;
 import com.credit_card_bill_tracker.backend.common.ApiResponseBuilder;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Value;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -15,19 +18,34 @@ public class AuthController {
     @Autowired
     private AuthService authService;
 
-    @Operation(summary = "User login", description = "Validates credentials and returns a JWT token")
+    @Value("${jwt.cookieName}")
+    private String jwtCookieName;
+
+    @Operation(summary = "User login", description = "Validates credentials and sets a JWT token cookie")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<AuthResponseDTO>> login(@Valid @RequestBody AuthRequestDTO request) {
+    public ResponseEntity<ApiResponse<AuthResponseDTO>> login(@Valid @RequestBody AuthRequestDTO request,
+                                                             HttpServletResponse response) {
         String token = authService.login(request.getUsername(), request.getPassword());
+        Cookie cookie = new Cookie(jwtCookieName, token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
         AuthResponseDTO result = new AuthResponseDTO(token);
         return ApiResponseBuilder.ok(result);
     }
 
-    @Operation(summary = "User logout", description = "Invalidates the provided JWT token")
+    @Operation(summary = "User logout", description = "Invalidates the JWT token cookie")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String authHeader) {
-        String token = authHeader.replace("Bearer ", "");
-        authService.logout(token);
+    public ResponseEntity<ApiResponse<Void>> logout(@CookieValue(value = "${jwt.cookieName}", required = false) String token,
+                                                   HttpServletResponse response) {
+        if (token != null) {
+            authService.logout(token);
+        }
+        Cookie cookie = new Cookie(jwtCookieName, "");
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
         return ApiResponseBuilder.noContent();
     }
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/JwtAuthenticationFilter.java
@@ -4,8 +4,10 @@ import com.credit_card_bill_tracker.backend.user.User;
 import com.credit_card_bill_tracker.backend.user.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,14 +26,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Autowired
     private UserRepository userRepository;
 
+    @Value("${jwt.cookieName}")
+    private String jwtCookieName;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = authHeader.substring(7);
+        String token = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (jwtCookieName.equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if (token != null) {
             String username = jwtUtil.extractUsername(token);
 
             if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/server/src/main/resources/application-template.properties
+++ b/server/src/main/resources/application-template.properties
@@ -16,6 +16,7 @@ server.port=8080
 # ===== JWT SECRET (optional for env config) =====
 jwt.secret=longsecretkeyforHS256
 jwt.expirationMs=86400000
+jwt.cookieName=jwt
 
 # ===== TIMEZONE (optional, for consistency in timestamps) =====
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
## Summary
- store JWT tokens in an HttpOnly cookie
- read JWT cookie in the authentication filter
- clear the cookie on logout
- make the cookie name configurable via `jwt.cookieName`

## Testing
- `./mvnw test` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a684d6e008323b711004321b9aee5