### PR TITLE
Refactor modal components

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:9000/api

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,35 +1,31 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Route, Routes, Navigate } from 'react-router-dom'
+import AppLayout from './components/AppLayout'
+import LoginPage from './pages/LoginPage'
+import { useAuthStore } from './store/auth'
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+function Dashboard() {
+  return <div>Welcome to your dashboard</div>
 }
 
-export default App
+export default function App() {
+  const loggedIn = useAuthStore((s) => s.loggedIn)
+
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/*"
+        element={loggedIn ? (
+          <AppLayout>
+            <Routes>
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="*" element={<Navigate to="/dashboard" />} />
+            </Routes>
+          </AppLayout>
+        ) : (
+          <Navigate to="/login" />
+        )}
+      />
+    </Routes>
+  )
+}

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,0 +1,35 @@
+import { ReactNode, useState } from 'react'
+import { NavLink, Outlet } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export default function AppLayout({ children }: { children?: ReactNode }) {
+  const { logout } = useAuth()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="min-h-screen flex">
+      {/* mobile overlay */}
+      {open && <div className="fixed inset-0 bg-black/40 z-20 sm:hidden" onClick={() => setOpen(false)} />}
+      <aside
+        className={cn(
+          'bg-sidebar text-sidebar-foreground w-56 border-r p-4 space-y-2 z-30 transition-transform',
+          'sm:translate-x-0 sm:static',
+          open ? 'translate-x-0 fixed inset-y-0 left-0' : '-translate-x-full fixed inset-y-0 left-0',
+        )}
+      >
+        <nav className="flex flex-col space-y-2">
+          <NavLink to="/dashboard">Dashboard</NavLink>
+          <NavLink to="/credit-cards">Credit Cards</NavLink>
+          <NavLink to="/expenses">Expenses</NavLink>
+          <Button variant="secondary" onClick={logout} className="mt-4 text-left">Logout</Button>
+        </nav>
+      </aside>
+      <main className="flex-1 p-4 sm:ml-56">
+        {children ? children : <Outlet />}
+      </main>
+      <Button className="sm:hidden fixed bottom-4 left-4 z-30" onClick={() => setOpen(true)}>Menu</Button>
+    </div>
+  )
+}

--- a/client/src/components/ManagementPage.tsx
+++ b/client/src/components/ManagementPage.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+import AppLayout from './AppLayout'
+
+export default function ManagementPage({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <AppLayout>
+      <h1 className="text-2xl font-bold mb-4">{title}</h1>
+      {children}
+    </AppLayout>
+  )
+}

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react'
+import { Dialog, DialogTrigger, DialogContent } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ModalProps {
+  title: string
+  triggerLabel: string
+  children: ReactNode
+  triggerClassName?: string
+  contentClassName?: string
+}
+
+export default function Modal({
+  title,
+  triggerLabel,
+  children,
+  triggerClassName,
+  contentClassName,
+}: ModalProps) {
+  return (
+    <Dialog>
+      <DialogTrigger>
+        <Button className={triggerClassName}>{triggerLabel}</Button>
+      </DialogTrigger>
+      <DialogContent className={contentClassName}>
+        <h2 className="text-lg font-bold mb-4">{title}</h2>
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/ModalForm.tsx
+++ b/client/src/components/ModalForm.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from 'react'
+import Modal from './Modal'
+import { DialogClose, useDialog } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ModalFormProps {
+  title: string
+  triggerLabel: string
+  onSubmit: () => void
+  children: ReactNode
+  triggerClassName?: string
+  contentClassName?: string
+}
+
+export default function ModalForm({
+  title,
+  triggerLabel,
+  onSubmit,
+  children,
+  ...rest
+}: ModalFormProps) {
+  return (
+    <Modal title={title} triggerLabel={triggerLabel} {...rest}>
+      <FormBody onSubmit={onSubmit}>{children}</FormBody>
+    </Modal>
+  )
+}
+
+function FormBody({ onSubmit, children }: { onSubmit: () => void; children: ReactNode }) {
+  const { setOpen } = useDialog()
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit()
+        setOpen(false)
+      }}
+      className="space-y-4"
+    >
+      {children}
+      <div className="flex justify-end space-x-2">
+        <DialogClose>
+          <Button type="button" variant="secondary">
+            Cancel
+          </Button>
+        </DialogClose>
+        <Button type="submit">Save</Button>
+      </div>
+    </form>
+  )
+}

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary'
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant = 'default', ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none px-4 py-2',
+        variant === 'secondary'
+          ? 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+          : 'bg-primary text-primary-foreground hover:bg-primary/90',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+Button.displayName = 'Button'
+
+export { Button }

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface DialogProps extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+interface Ctx {
+  open: boolean
+  setOpen: (o: boolean) => void
+}
+
+const DialogContext = React.createContext<Ctx | null>(null)
+
+function Dialog({ open = false, onOpenChange, ...props }: DialogProps) {
+  const [isOpen, setIsOpen] = React.useState(open)
+
+  const setOpen = (o: boolean) => {
+    setIsOpen(o)
+    onOpenChange?.(o)
+  }
+
+  return (
+    <DialogContext.Provider value={{ open: isOpen, setOpen }}>
+      {props.children}
+    </DialogContext.Provider>
+  )
+}
+
+function DialogTrigger({ children, className }: { children: React.ReactNode; className?: string }) {
+  const ctx = React.useContext(DialogContext)
+  if (!ctx) throw new Error('DialogTrigger must be used within Dialog')
+  return (
+    <div onClick={() => ctx.setOpen(true)} className={className}>
+      {children}
+    </div>
+  )
+}
+
+function DialogContent({ children, className }: { children: React.ReactNode; className?: string }) {
+  const ctx = React.useContext(DialogContext)
+  if (!ctx) return null
+  if (!ctx.open) return null
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" onClick={() => ctx.setOpen(false)}>
+      <div className={cn('bg-background p-4 rounded shadow w-96', className)} onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function useDialog() {
+  const ctx = React.useContext(DialogContext)
+  if (!ctx) throw new Error('useDialog must be used within Dialog')
+  return ctx
+}
+
+function DialogClose({ children, className }: { children: React.ReactNode; className?: string }) {
+  const { setOpen } = useDialog()
+  return (
+    <div onClick={() => setOpen(false)} className={className}>
+      {children}
+    </div>
+  )
+}
+
+export { Dialog, DialogTrigger, DialogContent, DialogClose, useDialog }

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom'
+import api from '@/lib/api'
+import { useAuthStore } from '@/store/auth'
+
+export function useAuth() {
+  const navigate = useNavigate()
+  const setLoggedIn = useAuthStore((s) => s.setLoggedIn)
+
+  const login = async (username: string, password: string) => {
+    await api.post('/auth/login', { username, password })
+    setLoggedIn(true)
+    navigate('/dashboard')
+  }
+
+  const logout = async () => {
+    await api.post('/auth/logout')
+    setLoggedIn(false)
+    navigate('/login')
+  }
+
+  return { login, logout }
+}

--- a/client/src/hooks/usePaymentSuggestions.ts
+++ b/client/src/hooks/usePaymentSuggestions.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import api from '@/lib/api'
+
+export interface PaymentSuggestion {
+  cardName: string
+  amount: number
+}
+
+export function usePaymentSuggestions(enabled = true) {
+  const [suggestions, setSuggestions] = useState<PaymentSuggestion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    setLoading(true)
+    api
+      .get('/bills/optimizer')
+      .then((res) => setSuggestions(res.data))
+      .catch(() => setError('Failed to load suggestions'))
+      .finally(() => setLoading(false))
+  }, [enabled])
+
+  return { suggestions, loading, error }
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
+})
+
+export default api

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,0 +1,52 @@
+import { FormEvent, useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(username, password)
+    } catch (err) {
+      setError('Login failed')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={onSubmit} className="space-y-4 w-80">
+        <h1 className="text-xl font-bold text-center">Login</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <div>
+          <label className="block mb-1" htmlFor="username">Username</label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1" htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded">
+          Login
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/client/src/store/auth.ts
+++ b/client/src/store/auth.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface AuthState {
+  loggedIn: boolean
+  setLoggedIn: (v: boolean) => void
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      loggedIn: false,
+      setLoggedIn: (v) => set({ loggedIn: v }),
+    }),
+    { name: 'auth' }
+  )
+)


### PR DESCRIPTION
## Summary
- add reusable `Modal` component wrapping dialog and button
- rewrite `ModalForm` to extend this new modal
- adjust auth logic for HttpOnly cookie

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom' etc.)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686a74122de88323bcd80075bb885bc4