### PR TITLE
Configure CORS for localhost dev

### DIFF
--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/SecurityConfig.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -32,6 +33,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/config/CorsConfig.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.credit_card_bill_tracker.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${cors.allowedOrigins}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/server/src/main/resources/application-template.properties
+++ b/server/src/main/resources/application-template.properties
@@ -11,12 +11,15 @@ spring.jpa.show-sql=true
 
 # ===== SERVER CONFIG =====
 spring.application.name=application-name
-server.port=8080
+server.port=9000
 
 # ===== JWT SECRET (optional for env config) =====
 jwt.secret=longsecretkeyforHS256
 jwt.expirationMs=86400000
 jwt.cookieName=jwt
+
+# ===== CORS CONFIG =====
+cors.allowedOrigins=http://localhost:5173
 
 # ===== TIMEZONE (optional, for consistency in timestamps) =====
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
## Summary
- allow origin configuration via `cors.allowedOrigins`
- add global CORS configuration and enable it in security
- run backend on port 9000 by default

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_686b2fe7c0a0832380c2807b967ec915