### PR TITLE
Add Google OAuth2 login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository hosts both the Spring Boot backend and the React frontend used t
 
 ### Features
 - User registration and authentication
+- Google login via OAuth2
 - Management of bank accounts, credit cards, expenses, and billing cycles
 - Bill payment tracking and spending summaries
 - Soft deletion with auditing timestamps
@@ -13,6 +14,7 @@ This repository hosts both the Spring Boot backend and the React frontend used t
 ### Getting Started
 1. Install **Java 21** and ensure `java -version` reports it.
 2. Copy `server/src/main/resources/application-template.properties` to `server/src/main/resources/application.properties` and edit the database credentials and JWT secret.
+   You will also need to provide Google OAuth2 client details and set `app.frontend-url` to your React app base URL.
 3. From the `server` directory run:
    ```bash
    ./mvnw spring-boot:run

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -7,6 +7,11 @@ export default function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
 
+  const googleLogin = () => {
+    const base = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '')
+    window.location.href = `${base}/oauth2/authorization/google`
+  }
+
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
@@ -45,6 +50,9 @@ export default function LoginPage() {
         </div>
         <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded">
           Login
+        </button>
+        <button type="button" onClick={googleLogin} className="w-full bg-red-600 text-white p-2 rounded">
+          Sign in with Google
         </button>
       </form>
     </div>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -38,10 +38,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-oauth2-client</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/CustomOAuth2UserService.java
@@ -1,0 +1,37 @@
+package com.credit_card_bill_tracker.backend.auth;
+
+import com.credit_card_bill_tracker.backend.user.UserDTO;
+import com.credit_card_bill_tracker.backend.user.UserRepository;
+import com.credit_card_bill_tracker.backend.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcUser;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OidcUser> {
+
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final OidcUserService delegate = new OidcUserService();
+
+    @Override
+    public OidcUser loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = delegate.loadUser(userRequest);
+        String email = oidcUser.getEmail();
+        userRepository.findByEmail(email).orElseGet(() -> {
+            UserDTO dto = new UserDTO();
+            dto.setUsername(email);
+            dto.setEmail(email);
+            dto.setPassword(UUID.randomUUID().toString());
+            return userService.register(dto);
+        });
+        return oidcUser;
+    }
+}

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/OAuth2LoginSuccessHandler.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,45 @@
+package com.credit_card_bill_tracker.backend.auth;
+
+import com.credit_card_bill_tracker.backend.user.User;
+import com.credit_card_bill_tracker.backend.user.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Value("${jwt.cookieName}")
+    private String jwtCookieName;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+        String email = oidcUser.getEmail();
+        User user = userRepository.findByEmail(email).orElse(null);
+        String username = user != null ? user.getUsername() : email;
+        String token = jwtUtil.generateToken(username);
+        Cookie cookie = new Cookie(jwtCookieName, token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+        response.sendRedirect(frontendUrl + "/dashboard");
+    }
+}

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/auth/SecurityConfig.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/auth/SecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -47,6 +49,10 @@ public class SecurityConfig {
                 )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((req, res, e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage()))
+                )
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(info -> info.userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler)
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/user/UserRepository.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/user/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public interface UserRepository extends BaseRepository<User, UUID> {
     Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
 }

--- a/server/src/main/resources/application-template.properties
+++ b/server/src/main/resources/application-template.properties
@@ -18,6 +18,14 @@ jwt.secret=longsecretkeyforHS256
 jwt.expirationMs=86400000
 jwt.cookieName=jwt
 
+# ===== OAUTH2 CONFIG =====
+spring.security.oauth2.client.registration.google.client-id=your-client-id
+spring.security.oauth2.client.registration.google.client-secret=your-client-secret
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
+
+# Frontend URL used for OAuth2 redirection
+app.frontend-url=http://localhost:5173
+
 # ===== CORS CONFIG =====
 cors.allowedOrigins=http://localhost:5173
 


### PR DESCRIPTION
## Summary
- allow logging in with a Google account
- add OAuth2 dependencies and configuration
- handle OAuth2 login with a success handler that issues JWT
- create custom OAuth2 user service to auto-register users
- expose Google login button in the React UI

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c8b02a71c8323a0069627fb208a97