### PR TITLE
Add sidebar theme utilities

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -218,6 +218,30 @@ body {
   .text-destructive-foreground {
     @apply text-[hsl(var(--destructive-foreground))];
   }
+  .bg-sidebar {
+    @apply bg-[hsl(var(--sidebar))];
+  }
+  .text-sidebar-foreground {
+    @apply text-[hsl(var(--sidebar-foreground))];
+  }
+  .bg-sidebar-primary {
+    @apply bg-[hsl(var(--sidebar-primary))];
+  }
+  .text-sidebar-primary-foreground {
+    @apply text-[hsl(var(--sidebar-primary-foreground))];
+  }
+  .bg-sidebar-accent {
+    @apply bg-[hsl(var(--sidebar-accent))];
+  }
+  .text-sidebar-accent-foreground {
+    @apply text-[hsl(var(--sidebar-accent-foreground))];
+  }
+  .border-sidebar-border {
+    @apply border-[hsl(var(--sidebar-border))];
+  }
+  .ring-sidebar-ring {
+    --tw-ring-color: hsl(var(--sidebar-ring));
+  }
   .border-border {
     @apply border-[hsl(var(--border))];
   }


### PR DESCRIPTION
## Summary
- extend theme utilities in `index.css` for sidebar colours

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*
- `npm ci` *(fails: blocked from downloading from registry)*

------
https://chatgpt.com/codex/tasks/task_e_687217b16d248323a791d9e38e395bdb