### PR TITLE
Add 404 page with API interceptor

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import LoginPage from './pages/LoginPage'
 import CreditCardsPage from './pages/CreditCardsPage'
 import BankAccountsPage from './pages/BankAccountsPage'
 import SpendingProfilesPage from './pages/SpendingProfilesPage'
+import NotFoundPage from './pages/NotFoundPage'
 import { useAuthStore } from './store/auth'
 
 function Dashboard() {
@@ -25,7 +26,8 @@ export default function App() {
               <Route path="/credit-cards" element={<CreditCardsPage />} />
               <Route path="/bank-accounts" element={<BankAccountsPage />} />
               <Route path="/spending-profiles" element={<SpendingProfilesPage />} />
-              <Route path="*" element={<Navigate to="/dashboard" />} />
+              <Route path="/404" element={<NotFoundPage />} />
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </AppLayout>
         ) : (

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -5,6 +5,16 @@ const api = axios.create({
   withCredentials: true,
 })
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      window.location.assign('/404')
+    }
+    return Promise.reject(error)
+  },
+)
+
 // -------- Authentication --------
 export const authApi = {
   login: (username: string, password: string) =>

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -1,0 +1,12 @@
+import AppLayout from '@/components/AppLayout'
+
+export default function NotFoundPage() {
+  return (
+    <AppLayout>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">404 - Not Found</h1>
+        <p>The requested resource could not be found.</p>
+      </div>
+    </AppLayout>
+  )
+}


### PR DESCRIPTION
## Summary
- add `NotFoundPage` component that uses `AppLayout`
- route unknown paths to the new page
- redirect to `/404` whenever the API returns 404 errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: network access to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874d4e5fd6c8323b6555221c34fdb43