### PR TITLE
Refine cycle creation workflow

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -74,6 +74,7 @@ export const billingCycleApi = {
   remove: (id: string) => api.delete(`/billing-cycles/${id}`),
   getDeferredBills: (id: string) =>
     api.get(`/billing-cycles/${id}/deferred-bills`),
+  complete: (id: string) => api.post(`/billing-cycles/${id}/complete`),
 }
 
 // -------- Bill Payments --------
@@ -82,7 +83,6 @@ export const billPaymentApi = {
   create: (payload: unknown) => api.post('/bills', payload),
   update: (id: string, payload: unknown) => api.put(`/bills/${id}`, payload),
   remove: (id: string) => api.delete(`/bills/${id}`),
-  markComplete: () => api.post('/bills/complete'),
 }
 
 // -------- Bill Optimizer --------

--- a/client/src/lib/dataSchema.ts
+++ b/client/src/lib/dataSchema.ts
@@ -66,16 +66,17 @@ export interface BillPayment {
     fromAccountId: string
     toCardId: string | null
     toAccountId: string | null
+    billingCycleId: string
     amount: number
     date: string
-    completed: boolean
 }
 
 export interface BillingCycle {
     id: string
     label: string
+    month: string
     completedDate: string
-    billPayments: BillPayment[]
+    updatedAt: string
 }
 
 export interface ExpenseSummary {
@@ -92,6 +93,7 @@ export interface Expense {
     id: string
     userId: string
     creditCardId: string
+    billingCycleId: string
     date: string
     amount: number
     description: string

--- a/client/src/pages/BillingCyclePlannerPage.tsx
+++ b/client/src/pages/BillingCyclePlannerPage.tsx
@@ -10,10 +10,23 @@ import {
 import {
   spendingProfileApi,
   billOptimizerApi,
+  billingCycleApi,
+  creditCardApi,
+  bankAccountApi,
+  expenseApi,
   billPaymentApi,
 } from '@/lib/api'
-import type { SpendingProfile } from '@/lib/dataSchema'
+import type {
+  SpendingProfile,
+  BillingCycle,
+  Card,
+  BankAccount,
+} from '@/lib/dataSchema'
+import dayjs from 'dayjs'
 import { Button } from '@/components/ui/button'
+import Modal from '@/components/Modal'
+import { DialogClose } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import {
   Table,
   TableBody,
@@ -43,6 +56,13 @@ export default function BillingCyclePlannerPage() {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [saving, setSaving] = useState(false)
   const [suggestions, setSuggestions] = useState<any[]>([])
+  const [currentCycle, setCurrentCycle] = useState<BillingCycle | null>(null)
+  const [cycles, setCycles] = useState<BillingCycle[]>([])
+  const [accounts, setAccounts] = useState<BankAccount[]>([])
+  const [cards, setCards] = useState<Card[]>([])
+  const [createOpen, setCreateOpen] = useState(false)
+  const [labelInput, setLabelInput] = useState('')
+  const [monthInput, setMonthInput] = useState(dayjs().format('MMMM').toUpperCase())
 
   // load profiles
   useEffect(() => {
@@ -61,9 +81,42 @@ export default function BillingCyclePlannerPage() {
         /* ignore */
       })
 
+    billingCycleApi
+      .getAll()
+      .then((res) => {
+        const cycles = res.data as BillingCycle[]
+        setCycles(cycles)
+        if (cycles.length) {
+          const latest = cycles
+            .slice()
+            .sort((a, b) => dayjs(a.updatedAt).diff(dayjs(b.updatedAt)))
+            .at(-1)!
+          setCurrentCycle(latest)
+          setLabelInput(latest.label)
+          setMonthInput(latest.month)
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      })
+
     billOptimizerApi
       .getSuggestions()
       .then((res) => setSuggestions(res.data))
+      .catch(() => {
+        /* ignore */
+      })
+
+    creditCardApi
+      .getAll()
+      .then((res) => setCards(res.data as Card[]))
+      .catch(() => {
+        /* ignore */
+      })
+
+    bankAccountApi
+      .getAll()
+      .then((res) => setAccounts(res.data as BankAccount[]))
       .catch(() => {
         /* ignore */
       })
@@ -77,10 +130,93 @@ export default function BillingCyclePlannerPage() {
     return () => clearInterval(id)
   })
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    if (!currentCycle) return
     setSaving(true)
-    // In a real app we would send changes to backend
-    setTimeout(() => setSaving(false), 500)
+    const accountMap: Record<string, string> = {}
+    accounts.forEach((a) => {
+      accountMap[a.name] = a.id
+    })
+
+    const promises: Promise<any>[] = []
+    profiles.forEach((p) => {
+      p.subRows.forEach((e) => {
+        const accId = accountMap[e.account]
+        if (!accId || !cards[0]) return
+        const payload = {
+          creditCardId: cards[0].id,
+          date: dayjs().format('YYYY-MM-DD'),
+          amount: e.amount,
+          description: e.description,
+          bankAccountIds: [accId],
+          billingCycleId: currentCycle.id,
+        }
+        promises.push(expenseApi.create(payload, p.id))
+      })
+    })
+
+    try {
+      await Promise.all(promises)
+    } catch {
+      /* ignore */
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const createCycle = () => {
+    const now = dayjs()
+    const payload = {
+      label: now.format('MMMM YYYY'),
+      month: now.format('MMMM').toUpperCase(),
+    }
+    billingCycleApi
+      .create(payload)
+      .then((res) => {
+        const cycle = res.data as BillingCycle
+        setCycles((c) => [...c, cycle])
+        setCurrentCycle(cycle)
+        setLabelInput(cycle.label)
+        setMonthInput(cycle.month)
+        setProfiles([])
+        setExpanded({})
+        setCreateOpen(false)
+      })
+      .catch(() => {
+        /* ignore */
+      })
+  }
+
+  const updateCycle = (payload: { label: string; month: string }) => {
+    if (!currentCycle) return
+    billingCycleApi
+      .update(currentCycle.id, payload)
+      .then((res) => {
+        const cycle = res.data as BillingCycle
+        setCycles((cs) => cs.map((c) => (c.id === cycle.id ? cycle : c)))
+        setCurrentCycle(cycle)
+        setLabelInput(cycle.label)
+        setMonthInput(cycle.month)
+      })
+      .catch(() => {
+        alert('A billing cycle with that label or month already exists.')
+        setLabelInput(currentCycle.label)
+        setMonthInput(currentCycle.month)
+      })
+  }
+
+  const handleLabelChange = (val: string) => {
+    setLabelInput(val)
+    if (!currentCycle) return
+    if (cycles.some((c) => c.id !== currentCycle.id && c.label === val)) return
+    updateCycle({ label: val, month: monthInput })
+  }
+
+  const handleMonthChange = (val: string) => {
+    setMonthInput(val)
+    if (!currentCycle) return
+    if (cycles.some((c) => c.id !== currentCycle.id && c.month === val)) return
+    updateCycle({ label: labelInput, month: val })
   }
 
   const addExpense = (profileId: string) => {
@@ -278,7 +414,58 @@ export default function BillingCyclePlannerPage() {
 
   return (
     <div className="flex flex-col gap-6 max-w-6xl mx-auto">
-      <h1 className="page-title">Billing Cycle Planner</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="page-title">Billing Cycle Planner</h1>
+        <Modal
+          title="Create new billing cycle?"
+          triggerLabel="New Billing Cycle"
+          triggerClassName=""
+          onOpen={() => setCreateOpen(true)}
+        >
+          {cycles.some((c) => c.month === dayjs().format('MMMM').toUpperCase()) && (
+            <p className="text-destructive text-sm">
+              Warning: you already have a cycle for this month.
+            </p>
+          )}
+          <div className="flex justify-end gap-2 mt-4">
+            <DialogClose asChild>
+              <Button variant="secondary" onClick={() => setCreateOpen(false)}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button onClick={createCycle}>Confirm</Button>
+            </DialogClose>
+          </div>
+        </Modal>
+      </div>
+      {currentCycle && (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-foreground">Viewing cycle: {currentCycle.label}</p>
+          <div className="flex gap-2 items-end">
+            <Input
+              className="w-40"
+              value={labelInput}
+              onChange={(e) => handleLabelChange(e.target.value)}
+              placeholder="Label"
+            />
+            <select
+              className="border rounded-md px-2 h-9 text-foreground"
+              value={monthInput}
+              onChange={(e) => handleMonthChange(e.target.value)}
+            >
+              {Array.from({ length: 12 }).map((_, i) => {
+                const m = dayjs().month(i).format('MMMM').toUpperCase()
+                return (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                )
+              })}
+            </select>
+          </div>
+        </div>
+      )}
       <Table className="border text-left">
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (
@@ -329,7 +516,8 @@ export default function BillingCyclePlannerPage() {
         <Button
           variant="destructive"
           className="button-destructive"
-          onClick={() => billPaymentApi.markComplete()}
+          onClick={() => currentCycle && billingCycleApi.complete(currentCycle.id)}
+          disabled={!currentCycle || !!currentCycle.completedDate}
         >
           Complete Bill Payments
         </Button>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -83,7 +83,7 @@ export default function DashboardPage() {
         }
       }
       for (const p of payments) {
-        if (p.toCardId && p.completed) {
+        if (p.toCardId) {
           const entry = unpaidMap[p.toCardId]
           if (entry) entry.amount -= p.amount
         }
@@ -112,10 +112,9 @@ export default function DashboardPage() {
         .sort((a, b) => dayjs(a.completedDate).unix() - dayjs(b.completedDate).unix())
         .map((c) => {
           const key = dayjs(c.completedDate).format('YYYY-MM')
-          const paymentsTotal = c.billPayments.reduce(
-            (sum, bp) => sum + bp.amount,
-            0,
-          )
+          const paymentsTotal = payments
+            .filter((p) => p.billingCycleId === c.id)
+            .reduce((sum, bp) => sum + bp.amount, 0)
           return {
             label: c.label,
             expenses: expenseGroup[key] || 0,

--- a/docs/System Architecture.md
+++ b/docs/System Architecture.md
@@ -79,6 +79,7 @@ erDiagram
         UUID id PK
         UUID user_id FK
         UUID credit_card_id FK
+        UUID billing_cycle_id FK
         date date
         double amount
         string description
@@ -92,9 +93,9 @@ erDiagram
         UUID from_account_id FK
         UUID to_card_id FK
         UUID to_account_id FK
+        UUID billing_cycle_id FK
         double amount
         date date
-        boolean completed
         datetime created_at
         datetime updated_at
         datetime deleted_at
@@ -103,6 +104,7 @@ erDiagram
         UUID id PK
         UUID user_id FK
         string label
+        string month
         date completed_date
         datetime created_at
         datetime updated_at
@@ -140,6 +142,7 @@ erDiagram
     bank_accounts ||--o{ bill_payments : sends
     credit_cards ||--o{ bill_payments : receives
     billing_cycles ||--o{ bill_payments : contains
+    billing_cycles ||--o{ expenses : includes
     bank_accounts }o--o{ spending_profiles : "belongs to"
 ```
 
@@ -186,6 +189,7 @@ erDiagram
 | id | UUID | primary key |
 | user_id | UUID | FK to users |
 | credit_card_id | UUID | FK to credit_cards |
+| billing_cycle_id | UUID | FK to billing_cycles |
 | date | date | transaction date |
 | amount | double | amount spent |
 | description | string | merchant or notes |
@@ -201,9 +205,9 @@ erDiagram
 | from_account_id | UUID | FK to bank_accounts |
 | to_card_id | UUID | FK to credit_cards |
 | to_account_id | UUID | FK to bank_accounts |
+| billing_cycle_id | UUID | FK to billing_cycles |
 | amount | double | payment amount |
 | date | date | payment date |
-| completed | boolean | if payment executed |
 | created_at | datetime | record creation |
 | updated_at | datetime | last update |
 | deleted_at | datetime | soft delete timestamp |
@@ -213,7 +217,8 @@ erDiagram
 | --- | --- | --- |
 | id | UUID | primary key |
 | user_id | UUID | FK to users |
-| label | string | cycle name |
+| label | string | cycle name, unique per user |
+| month | string | target month, unique per user |
 | completed_date | date | closing date |
 | created_at | datetime | record creation |
 | updated_at | datetime | last update |
@@ -238,7 +243,7 @@ erDiagram
 | --- | --- | --- |
 | id | UUID | primary key |
 | user_id | UUID | FK to users |
-| name | string | profile label |
+| name | string | profile label, unique per user |
 | created_at | datetime | record creation |
 | updated_at | datetime | last update |
 | deleted_at | datetime | soft delete timestamp |

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycle.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycle.java
@@ -2,6 +2,7 @@ package com.credit_card_bill_tracker.backend.billingcycle;
 
 import com.credit_card_bill_tracker.backend.billpayment.BillPayment;
 import com.credit_card_bill_tracker.backend.common.BaseEntity;
+import com.credit_card_bill_tracker.backend.expense.Expense;
 import com.credit_card_bill_tracker.backend.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -12,7 +13,13 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-@Table(name = "billing_cycles")
+@Table(
+        name = "billing_cycles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_cycle_user_label", columnNames = {"user_id", "label"}),
+                @UniqueConstraint(name = "uk_cycle_user_month", columnNames = {"user_id", "month"})
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -21,17 +28,18 @@ public class BillingCycle extends BaseEntity {
     @ManyToOne(optional = false)
     private User user;
 
-    @ManyToMany
-    @JoinTable(
-            name = "billing_cycle_payments",
-            joinColumns = @JoinColumn(name = "billing_cycle_id"),
-            inverseJoinColumns = @JoinColumn(name = "bill_payment_id")
-    )
+    @OneToMany(mappedBy = "billingCycle")
     private List<BillPayment> billPayments;
+
+    @OneToMany(mappedBy = "billingCycle")
+    private List<Expense> expenses;
 
     @Column(nullable = false)
     private String label; // e.g. "June 2025"
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    private java.time.Month month;
+
     private LocalDate completedDate;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleController.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleController.java
@@ -53,6 +53,13 @@ public class BillingCycleController {
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
     }
 
+    @Operation(summary = "Complete billing cycle", description = "Marks the cycle as completed")
+    @PostMapping("/{id}/complete")
+    public ResponseEntity<BillingCycleResponseDTO> complete(@AuthenticationPrincipal User user, @PathVariable UUID id) {
+        BillingCycleResponseDTO result = service.complete(user, id);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
+    }
+
     @Operation(summary = "Delete billing cycle", description = "Deletes the specified billing cycle")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@AuthenticationPrincipal User user, @PathVariable UUID id) {

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleMapper.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleMapper.java
@@ -1,53 +1,34 @@
 package com.credit_card_bill_tracker.backend.billingcycle;
 
-import com.credit_card_bill_tracker.backend.billpayment.BillPayment;
-import com.credit_card_bill_tracker.backend.billpayment.BillPaymentMapper;
-import com.credit_card_bill_tracker.backend.billpayment.BillPaymentRepository;
-import com.credit_card_bill_tracker.backend.common.errors.ResourceNotFoundException;
 import com.credit_card_bill_tracker.backend.billingcycle.BillingCycleRequestDTO;
 import com.credit_card_bill_tracker.backend.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class BillingCycleMapper {
-    private final BillPaymentRepository billPaymentRepo;
-    private final BillPaymentMapper billPaymentMapper;
 
     public BillingCycle toEntity(BillingCycleRequestDTO dto, User user) {
         BillingCycle entity = new BillingCycle();
         entity.setUser(user);
         entity.setLabel(dto.getLabel());
-        entity.setCompletedDate(dto.getCompletedDate());
-        List<BillPayment> payments = dto.getBillPaymentIds().stream()
-                .map(id -> billPaymentRepo.findById(id)
-                        .orElseThrow(() -> new ResourceNotFoundException("Bill payment not found")))
-                .toList();
-        entity.setBillPayments(payments);
+        entity.setMonth(dto.getMonth());
         return entity;
     }
 
     public void updateEntity(BillingCycle entity, BillingCycleRequestDTO dto) {
         entity.setLabel(dto.getLabel());
-        entity.setCompletedDate(dto.getCompletedDate());
-        List<BillPayment> payments = dto.getBillPaymentIds().stream()
-                .map(id -> billPaymentRepo.findById(id)
-                        .orElseThrow(() -> new ResourceNotFoundException("Bill payment not found")))
-                .toList();
-        entity.setBillPayments(payments);
+        entity.setMonth(dto.getMonth());
     }
 
     public BillingCycleResponseDTO toResponseDTO(BillingCycle entity) {
         BillingCycleResponseDTO dto = new BillingCycleResponseDTO();
         dto.setId(entity.getId());
         dto.setLabel(entity.getLabel());
+        dto.setMonth(entity.getMonth());
         dto.setCompletedDate(entity.getCompletedDate());
-        dto.setBillPayments(entity.getBillPayments().stream()
-                .map(billPaymentMapper::toResponseDto)
-                .toList());
+        dto.setUpdatedAt(entity.getUpdatedAt());
         return dto;
     }
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleRepository.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleRepository.java
@@ -9,4 +9,14 @@ import java.util.UUID;
 @Repository
 public interface BillingCycleRepository extends BaseRepository<BillingCycle, UUID> {
     List<BillingCycle> findByUserId(UUID userId);
+
+    BillingCycle findFirstByUserIdOrderByUpdatedAtDesc(UUID userId);
+
+    boolean existsByUserIdAndLabel(UUID userId, String label);
+
+    boolean existsByUserIdAndMonth(UUID userId, java.time.Month month);
+
+    boolean existsByUserIdAndLabelAndIdNot(UUID userId, String label, UUID id);
+
+    boolean existsByUserIdAndMonthAndIdNot(UUID userId, java.time.Month month, UUID id);
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleRequestDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleRequestDTO.java
@@ -2,17 +2,17 @@ package com.credit_card_bill_tracker.backend.billingcycle;
 
 import lombok.Data;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.UUID;
+import java.time.Month;
 
 @Data
 public class BillingCycleRequestDTO {
     @NotBlank
     @Size(max = 100)
     private String label;
-    private LocalDate completedDate;
-    private List<UUID> billPaymentIds;
+
+    @NotNull
+    private Month month;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleResponseDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billingcycle/BillingCycleResponseDTO.java
@@ -1,12 +1,11 @@
 package com.credit_card_bill_tracker.backend.billingcycle;
 
-import com.credit_card_bill_tracker.backend.billpayment.BillPaymentResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.time.Month;
 import java.util.UUID;
 
 @Data
@@ -15,6 +14,7 @@ import java.util.UUID;
 public class BillingCycleResponseDTO {
     private UUID id;
     private String label;
+    private Month month;
     private LocalDate completedDate;
-    private List<BillPaymentResponseDTO> billPayments;
+    private java.time.LocalDateTime updatedAt;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPayment.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPayment.java
@@ -2,11 +2,11 @@ package com.credit_card_bill_tracker.backend.billpayment;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
 import com.credit_card_bill_tracker.backend.common.BaseEntity;
+import com.credit_card_bill_tracker.backend.billingcycle.BillingCycle;
 import com.credit_card_bill_tracker.backend.creditcard.CreditCard;
 import com.credit_card_bill_tracker.backend.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
@@ -33,6 +33,7 @@ public class BillPayment extends BaseEntity {
 
     private LocalDate date;
 
-    @Column(nullable = false)
-    private boolean completed = false;
+
+    @ManyToOne(optional = false)
+    private BillingCycle billingCycle;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentController.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentController.java
@@ -1,6 +1,5 @@
 package com.credit_card_bill_tracker.backend.billpayment;
 
-import com.credit_card_bill_tracker.backend.billingcycle.BillingCycleResponseDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import com.credit_card_bill_tracker.backend.user.User;
@@ -49,10 +48,4 @@ public class BillPaymentController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Complete billing cycle", description = "Marks the current billing cycle's bills as paid")
-    @PostMapping("/complete")
-    public ResponseEntity<BillingCycleResponseDTO> markAsComplete(@AuthenticationPrincipal User user) {
-        BillingCycleResponseDTO result = service.markBillsComplete(user);
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
-    }
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentMapper.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentMapper.java
@@ -2,7 +2,7 @@ package com.credit_card_bill_tracker.backend.billpayment;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccountRepository;
 import com.credit_card_bill_tracker.backend.creditcard.CreditCardRepository;
-import com.credit_card_bill_tracker.backend.billpayment.BillPaymentRequestDTO;
+import com.credit_card_bill_tracker.backend.billingcycle.BillingCycleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,15 +12,16 @@ public class BillPaymentMapper {
 
     private final CreditCardRepository creditCardRepository;
     private final BankAccountRepository bankAccountRepository;
+    private final BillingCycleRepository billingCycleRepository;
 
     public BillPaymentRequestDTO toDto(BillPayment entity) {
         BillPaymentRequestDTO dto = new BillPaymentRequestDTO();
         dto.setAmount(entity.getAmount());
         dto.setDate(entity.getDate());
-        dto.setCompleted(entity.isCompleted());
         dto.setFromAccountId(entity.getFromAccount().getId());
         if (entity.getToCard() != null) dto.setToCardId(entity.getToCard().getId());
         if (entity.getToAccount() != null) dto.setToAccountId(entity.getToAccount().getId());
+        dto.setBillingCycleId(entity.getBillingCycle().getId());
         return dto;
     }
 
@@ -29,10 +30,10 @@ public class BillPaymentMapper {
         dto.setId(entity.getId());
         dto.setAmount(entity.getAmount());
         dto.setDate(entity.getDate());
-        dto.setCompleted(entity.isCompleted());
         dto.setFromAccountId(entity.getFromAccount().getId());
         if (entity.getToCard() != null) dto.setToCardId(entity.getToCard().getId());
         if (entity.getToAccount() != null) dto.setToAccountId(entity.getToAccount().getId());
+        dto.setBillingCycleId(entity.getBillingCycle().getId());
         return dto;
     }
 
@@ -40,10 +41,10 @@ public class BillPaymentMapper {
         BillPayment entity = new BillPayment();
         entity.setAmount(dto.getAmount());
         entity.setDate(dto.getDate());
-        entity.setCompleted(dto.isCompleted());
         entity.setFromAccount(bankAccountRepository.getReferenceById(dto.getFromAccountId()));
         if (dto.getToCardId() != null) entity.setToCard(creditCardRepository.getReferenceById(dto.getToCardId()));
         if (dto.getToAccountId() != null) entity.setToAccount(bankAccountRepository.getReferenceById(dto.getToAccountId()));
+        entity.setBillingCycle(billingCycleRepository.getReferenceById(dto.getBillingCycleId()));
         return entity;
     }
 
@@ -53,5 +54,6 @@ public class BillPaymentMapper {
         entity.setFromAccount(bankAccountRepository.getReferenceById(dto.getFromAccountId()));
         entity.setToCard(dto.getToCardId() != null ? creditCardRepository.getReferenceById(dto.getToCardId()) : null);
         entity.setToAccount(dto.getToAccountId() != null ? bankAccountRepository.getReferenceById(dto.getToAccountId()) : null);
+        entity.setBillingCycle(billingCycleRepository.getReferenceById(dto.getBillingCycleId()));
     }
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentRepository.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentRepository.java
@@ -6,8 +6,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface BillPaymentRepository extends BaseRepository<BillPayment, UUID> {
-
-    List<BillPayment> findByUserIdAndCompletedFalse(UUID userId);
-
     List<BillPayment> findByUserId(UUID userId);
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentRequestDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentRequestDTO.java
@@ -12,5 +12,5 @@ public class BillPaymentRequestDTO {
     private UUID toAccountId;
     private double amount;
     private LocalDate date;
-    private boolean completed;
+    private UUID billingCycleId;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentResponseDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/billpayment/BillPaymentResponseDTO.java
@@ -13,5 +13,5 @@ public class BillPaymentResponseDTO {
     private UUID toAccountId;
     private double amount;
     private LocalDate date;
-    private boolean completed;
+    private UUID billingCycleId;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expense/Expense.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expense/Expense.java
@@ -2,6 +2,7 @@ package com.credit_card_bill_tracker.backend.expense;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
 import com.credit_card_bill_tracker.backend.common.BaseEntity;
+import com.credit_card_bill_tracker.backend.billingcycle.BillingCycle;
 import com.credit_card_bill_tracker.backend.creditcard.CreditCard;
 import com.credit_card_bill_tracker.backend.user.User;
 import jakarta.persistence.*;
@@ -41,4 +42,7 @@ public class Expense extends BaseEntity {
             inverseJoinColumns = @JoinColumn(name = "bank_account_id")
     )
     private List<BankAccount> bankAccounts;
+
+    @ManyToOne(optional = false)
+    private BillingCycle billingCycle;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseMapper.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseMapper.java
@@ -1,14 +1,20 @@
 package com.credit_card_bill_tracker.backend.expense;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccount;
+import com.credit_card_bill_tracker.backend.billingcycle.BillingCycleRepository;
 import com.credit_card_bill_tracker.backend.expense.ExpenseRequestDTO;
 import org.springframework.stereotype.Component;
 
 import java.util.stream.Collectors;
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class ExpenseMapper {
+
+    private final BillingCycleRepository billingCycleRepository;
 
     public ExpenseRequestDTO toDto(Expense entity) {
         ExpenseRequestDTO dto = new ExpenseRequestDTO();
@@ -19,6 +25,7 @@ public class ExpenseMapper {
         dto.setBankAccountIds(entity.getBankAccounts().stream()
                 .map(BankAccount::getId)
                 .collect(Collectors.toList()));
+        dto.setBillingCycleId(entity.getBillingCycle().getId());
         return dto;
     }
 
@@ -33,6 +40,7 @@ public class ExpenseMapper {
         dto.setBankAccountIds(entity.getBankAccounts().stream()
                 .map(BankAccount::getId)
                 .collect(Collectors.toList()));
+        dto.setBillingCycleId(entity.getBillingCycle().getId());
         return dto;
     }
 
@@ -41,6 +49,7 @@ public class ExpenseMapper {
         entity.setDate(dto.getDate());
         entity.setAmount(dto.getAmount());
         entity.setDescription(dto.getDescription());
+        entity.setBillingCycle(billingCycleRepository.getReferenceById(dto.getBillingCycleId()));
         return entity;
     }
 
@@ -48,5 +57,6 @@ public class ExpenseMapper {
         entity.setDate(dto.getDate());
         entity.setAmount(dto.getAmount());
         entity.setDescription(dto.getDescription());
+        entity.setBillingCycle(billingCycleRepository.getReferenceById(dto.getBillingCycleId()));
     }
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseRequestDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseRequestDTO.java
@@ -15,4 +15,5 @@ public class ExpenseRequestDTO {
     @Size(max = 255)
     private String description;
     private List<UUID> bankAccountIds;
+    private UUID billingCycleId;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseResponseDTO.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseResponseDTO.java
@@ -15,4 +15,5 @@ public class ExpenseResponseDTO {
     private double amount;
     private String description;
     private List<UUID> bankAccountIds;
+    private UUID billingCycleId;
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/expense/ExpenseService.java
@@ -54,13 +54,10 @@ public class ExpenseService {
 //    }
 
     public ExpenseResponseDTO createWithSpendingProfile(User user, ExpenseRequestDTO dto, UUID spendingProfileId) {
-        Expense entity = new Expense();
+        Expense entity = mapper.fromDto(dto);
         entity.setUser(user);
         entity.setCreditCard(creditCardRepo.findById(dto.getCreditCardId())
                 .orElseThrow(() -> new ResourceNotFoundException("Credit card not found")));
-        entity.setDate(dto.getDate());
-        entity.setAmount(dto.getAmount());
-        entity.setDescription(dto.getDescription());
 
         SpendingProfile profile = spendingProfileRepo.findById(spendingProfileId)
                 .filter(p -> p.getUser().getId().equals(user.getId()))

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfile.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfile.java
@@ -11,7 +11,10 @@ import lombok.Setter;
 import java.util.List;
 
 @Entity
-@Table(name = "spending_profiles")
+@Table(
+        name = "spending_profiles",
+        uniqueConstraints = @UniqueConstraint(name = "uk_profile_user_name", columnNames = {"user_id", "name"})
+)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfileRepository.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfileRepository.java
@@ -7,4 +7,8 @@ import java.util.UUID;
 
 public interface SpendingProfileRepository extends BaseRepository<SpendingProfile, UUID> {
     List<SpendingProfile> findByUserId(UUID userId);
+
+    boolean existsByUserIdAndName(UUID userId, String name);
+
+    boolean existsByUserIdAndNameAndIdNot(UUID userId, String name, UUID id);
 }

--- a/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfileService.java
+++ b/server/src/main/java/com/credit_card_bill_tracker/backend/spendingprofile/SpendingProfileService.java
@@ -2,6 +2,7 @@ package com.credit_card_bill_tracker.backend.spendingprofile;
 
 import com.credit_card_bill_tracker.backend.bankaccount.BankAccountRepository;
 import com.credit_card_bill_tracker.backend.common.errors.ResourceNotFoundException;
+import com.credit_card_bill_tracker.backend.common.errors.BadRequestException;
 import com.credit_card_bill_tracker.backend.user.User;
 import com.credit_card_bill_tracker.backend.spendingprofile.SpendingProfileRequestDTO;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,9 @@ public class SpendingProfileService {
     }
 
     public SpendingProfileResponseDTO create(User user, SpendingProfileRequestDTO dto) {
+        if (repository.existsByUserIdAndName(user.getId(), dto.getName())) {
+            throw new BadRequestException("Spending profile with that name already exists");
+        }
         SpendingProfile profile = mapper.fromDto(dto);
         profile.setUser(user);
         profile.setBankAccounts(dto.getBankAccountIds().stream()
@@ -39,6 +43,9 @@ public class SpendingProfileService {
         SpendingProfile entity = repository.findById(id)
                 .filter(p -> p.getUser().getId().equals(user.getId()))
                 .orElseThrow(() -> new ResourceNotFoundException("Spending profile not found"));
+        if (repository.existsByUserIdAndNameAndIdNot(user.getId(), dto.getName(), id)) {
+            throw new BadRequestException("Spending profile with that name already exists");
+        }
         mapper.updateEntityFromDto(entity, dto);
         entity.setBankAccounts(dto.getBankAccountIds().stream()
                 .map(bankAccountRepo::findById)

--- a/server/src/main/resources/db/changelog/db.changelog-init.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-init.xml
@@ -82,13 +82,16 @@
             <column name="label" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="completed_date" type="date">
+            <column name="month" type="varchar(20)">
                 <constraints nullable="false"/>
             </column>
+            <column name="completed_date" type="date"/>
             <column name="created_at" type="timestamp"/>
             <column name="updated_at" type="timestamp"/>
             <column name="deleted_at" type="timestamp"/>
         </createTable>
+        <addUniqueConstraint tableName="billing_cycles" columnNames="user_id,label" constraintName="uk_cycle_user_label"/>
+        <addUniqueConstraint tableName="billing_cycles" columnNames="user_id,month" constraintName="uk_cycle_user_month"/>
 
         <!-- Bill Payments table -->
         <createTable tableName="bill_payment">
@@ -111,8 +114,8 @@
                 <constraints nullable="false"/>
             </column>
             <column name="date" type="date"/>
-            <column name="completed" type="boolean">
-                <constraints nullable="false"/>
+            <column name="billing_cycle_id" type="uuid">
+                <constraints nullable="false" foreignKeyName="fk_bill_payment_cycle" references="billing_cycles(id)"/>
             </column>
             <column name="created_at" type="timestamp"/>
             <column name="updated_at" type="timestamp"/>
@@ -164,6 +167,9 @@
             <column name="amount" type="decimal(19,2)">
                 <constraints nullable="false"/>
             </column>
+            <column name="billing_cycle_id" type="uuid">
+                <constraints nullable="false" foreignKeyName="fk_expense_billing_cycle" references="billing_cycles(id)"/>
+            </column>
             <column name="description" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
@@ -183,16 +189,6 @@
         </createTable>
         <addPrimaryKey tableName="expense_bank_accounts" columnNames="expense_id, bank_account_id"/>
 
-        <!-- Billing Cycle Payments junction table -->
-        <createTable tableName="billing_cycle_payments">
-            <column name="billing_cycle_id" type="uuid">
-                <constraints nullable="false" foreignKeyName="fk_billing_cycle_payments_billing_cycle" references="billing_cycles(id)"/>
-            </column>
-            <column name="bill_payment_id" type="uuid">
-                <constraints nullable="false" foreignKeyName="fk_billing_cycle_payments_bill_payment" references="bill_payment(id)"/>
-            </column>
-        </createTable>
-        <addPrimaryKey tableName="billing_cycle_payments" columnNames="billing_cycle_id, bill_payment_id"/>
 
         <!-- Expense Summaries table -->
         <createTable tableName="expense_summaries">
@@ -238,6 +234,7 @@
             <column name="updated_at" type="timestamp"/>
             <column name="deleted_at" type="timestamp"/>
         </createTable>
+        <addUniqueConstraint tableName="spending_profiles" columnNames="user_id,name" constraintName="uk_profile_user_name"/>
 
         <!-- Spending Profile Bank Accounts junction table -->
         <createTable tableName="spending_profile_bank_accounts">

--- a/server/src/main/resources/db/changelog/db.changelog-testdata.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-testdata.xml
@@ -48,6 +48,7 @@
             <column name="credit_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="date" valueDate="2024-01-05"/>
             <column name="amount" valueNumeric="50.00"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
             <column name="description" value="Groceries"/>
         </insert>
 
@@ -64,6 +65,7 @@
             <column name="credit_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="date" valueDate="2024-01-06"/>
             <column name="amount" valueNumeric="40.00"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
             <column name="description" value="Fuel"/>
         </insert>
 
@@ -78,6 +80,7 @@
             <column name="credit_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="date" valueDate="2024-01-07"/>
             <column name="amount" valueNumeric="30.00"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
             <column name="description" value="Dinner"/>
         </insert>
 
@@ -96,6 +99,7 @@
             <column name="credit_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="date" valueDate="2024-01-08"/>
             <column name="amount" valueNumeric="20.00"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
             <column name="description" value="Stationery"/>
         </insert>
 
@@ -112,7 +116,7 @@
             <column name="to_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="amount" valueNumeric="25.00"/>
             <column name="date" valueDate="2024-01-10"/>
-            <column name="completed" valueBoolean="true"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
         </insert>
 
         <insert tableName="bill_payment">
@@ -122,7 +126,7 @@
             <column name="to_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="amount" valueNumeric="20.00"/>
             <column name="date" valueDate="2024-01-15"/>
-            <column name="completed" valueBoolean="true"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
         </insert>
 
         <insert tableName="bill_payment">
@@ -132,7 +136,7 @@
             <column name="to_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="amount" valueNumeric="30.00"/>
             <column name="date" valueDate="2024-01-20"/>
-            <column name="completed" valueBoolean="true"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
         </insert>
 
         <insert tableName="bill_payment">
@@ -142,7 +146,7 @@
             <column name="to_card_id" value="44444444-4444-4444-4444-444444444444"/>
             <column name="amount" valueNumeric="10.00"/>
             <column name="date" valueDate="2024-01-25"/>
-            <column name="completed" valueBoolean="true"/>
+            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
         </insert>
 
         <!-- Billing cycle with the payment -->
@@ -150,28 +154,10 @@
             <column name="id" value="77777777-7777-7777-7777-777777777777"/>
             <column name="user_id" value="11111111-1111-1111-1111-111111111111"/>
             <column name="label" value="January 2024"/>
+            <column name="month" value="JANUARY"/>
             <column name="completed_date" valueDate="2024-01-31"/>
         </insert>
 
-        <insert tableName="billing_cycle_payments">
-            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
-            <column name="bill_payment_id" value="66666666-6666-6666-6666-666666666666"/>
-        </insert>
-
-        <insert tableName="billing_cycle_payments">
-            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
-            <column name="bill_payment_id" value="66666666-6666-6666-6666-666666666667"/>
-        </insert>
-
-        <insert tableName="billing_cycle_payments">
-            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
-            <column name="bill_payment_id" value="66666666-6666-6666-6666-666666666668"/>
-        </insert>
-
-        <insert tableName="billing_cycle_payments">
-            <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
-            <column name="bill_payment_id" value="66666666-6666-6666-6666-666666666669"/>
-        </insert>
 
         <!-- Expense summary record -->
         <insert tableName="expense_summaries">


### PR DESCRIPTION
## Summary
- enforce unique billing cycle labels and months per user
- ensure spending profile names are unique per user
- add updatedAt to billing cycle responses
- warn when creating duplicate cycles and allow editing label/month in planner
- disable complete button once cycle is completed
- make cycle planner save expenses to backend and update cycle settings immediately
- use reusable Modal component for creating cycles

## Testing
- `./server/mvnw -q test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a2a0a6f5883238003f949dd63e0c5