### PR TITLE
Update CI to run on develop branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ name: Testing CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   JWT_SECRET: ${{ secrets.JWT_SECRET }}


### PR DESCRIPTION
## Summary
- trigger the CI workflow on pushes and pull requests to `develop`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_688add6e9a2483238037a5a9512544e4