### PR TITLE
Refactor cycle planner UI into hooks

### DIFF
--- a/client/src/components/BillPaymentSection.tsx
+++ b/client/src/components/BillPaymentSection.tsx
@@ -1,0 +1,122 @@
+import { useMemo } from 'react'
+import dayjs from 'dayjs'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import EditableTable from './EditableTable'
+import { Button } from './ui/button'
+import { useBillPayments } from '@/hooks/useBillPayments'
+import type { BillPayment, Card, BankAccount } from '@/lib/dataSchema'
+
+interface Props {
+  accounts: BankAccount[]
+  cards: Card[]
+}
+
+export default function BillPaymentSection({ accounts, cards }: Props) {
+  const { payments, addPayment, removePayment, updatePayment } = useBillPayments()
+
+  const columns = useMemo<ColumnDef<BillPayment>[]>(
+    () => [
+      {
+        id: 'date',
+        header: 'Date',
+        cell: ({ row }) => (
+          <input
+            type="date"
+            className="border px-1"
+            value={row.original.date}
+            onChange={(e) => updatePayment(row.original.id, { date: e.target.value })}
+          />
+        ),
+      },
+      {
+        id: 'from',
+        header: 'From Account',
+        cell: ({ row }) => (
+          <select
+            className="border px-1 text-foreground"
+            value={row.original.fromAccountId}
+            onChange={(e) => updatePayment(row.original.id, { fromAccountId: e.target.value })}
+          >
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        ),
+      },
+      {
+        id: 'to',
+        header: 'To Card',
+        cell: ({ row }) => (
+          <select
+            className="border px-1 text-foreground"
+            value={row.original.toCardId ?? ''}
+            onChange={(e) => updatePayment(row.original.id, { toCardId: e.target.value })}
+          >
+            <option value="">--</option>
+            {cards.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.cardName}
+              </option>
+            ))}
+          </select>
+        ),
+      },
+      {
+        id: 'amount',
+        header: 'Amount',
+        cell: ({ row }) => (
+          <input
+            type="number"
+            className="w-24 border px-1"
+            value={row.original.amount}
+            onChange={(e) => updatePayment(row.original.id, { amount: parseFloat(e.target.value) })}
+          />
+        ),
+      },
+    ],
+    [accounts, cards],
+  )
+
+  const table = useReactTable({
+    data: payments,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div className="flex flex-col gap-2">
+      <EditableTable
+        table={table}
+        renderRowAction={(row) => (
+          <Button variant="destructive" size="sm" onClick={() => removePayment(row.original.id)}>
+            Delete
+          </Button>
+        )}
+      />
+      <div className="mt-2">
+        <Button
+          size="sm"
+          onClick={() =>
+            addPayment({
+              id: Math.random().toString(),
+              amount: 0,
+              date: dayjs().format('YYYY-MM-DD'),
+              billingCycleId: '',
+              fromAccountId: accounts[0]?.id || '',
+              toCardId: cards[0]?.id || null,
+              toAccountId: null,
+            })
+          }
+        >
+          Add Payment
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/EditableTable.tsx
+++ b/client/src/components/EditableTable.tsx
@@ -1,0 +1,39 @@
+import { flexRender, Row, Table as ReactTable } from '@tanstack/react-table'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table'
+import { ReactNode } from 'react'
+
+interface Props<T> {
+  table: ReactTable<T>
+  renderRowAction?: (row: Row<T>) => ReactNode
+}
+
+export default function EditableTable<T>({ table, renderRowAction }: Props<T>) {
+  return (
+    <Table className="border text-left">
+      <TableHeader>
+        {table.getHeaderGroups().map((hg) => (
+          <TableRow key={hg.id}>
+            {hg.headers.map((h) => (
+              <TableHead key={h.id} className="text-foreground">
+                {flexRender(h.column.columnDef.header, h.getContext())}
+              </TableHead>
+            ))}
+            {renderRowAction && <TableHead />}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <TableCell key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+            {renderRowAction && <TableCell>{renderRowAction(row)}</TableCell>}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/client/src/components/ProfileSection.tsx
+++ b/client/src/components/ProfileSection.tsx
@@ -1,0 +1,139 @@
+import { useMemo } from 'react'
+import { formatNumber } from 'accounting-js'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getExpandedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import EditableTable from './EditableTable'
+import { Button } from './ui/button'
+import { ProfileRow, ExpenseRow, useProfiles } from '@/hooks/useProfiles'
+
+export default function ProfileSection() {
+  const { profiles, expanded, setExpanded, addExpense, updateExpense, allAccounts } = useProfiles()
+
+  const columns = useMemo<ColumnDef<ProfileRow>[]>(
+    () => {
+      const accountCols: ColumnDef<ProfileRow>[] = allAccounts.map((acc) => ({
+        id: acc,
+        header: acc,
+        cell: ({ row }) => {
+          if (row.depth !== 0) return null
+          const total = row.original.subRows
+            .filter((e) => e.account === acc)
+            .reduce((sum, e) => sum + e.amount, 0)
+          return total ? formatNumber(total, 2) : ''
+        },
+      }))
+
+      return [
+        {
+          id: 'name',
+          header: 'Category',
+          cell: ({ row }) => {
+            const isExpanded = row.getIsExpanded()
+            return (
+              <div className="flex items-center gap-2">
+                {row.getCanExpand() && (
+                  <button
+                    type="button"
+                    onClick={row.getToggleExpandedHandler()}
+                    className="font-mono"
+                  >
+                    {isExpanded ? '-' : '+'}
+                  </button>
+                )}
+                {row.depth === 0 && (
+                  <span className="font-semibold text-foreground">
+                    {(row.original as ProfileRow).name}
+                  </span>
+                )}
+              </div>
+            )
+          },
+        },
+        ...accountCols,
+        {
+          id: 'total',
+          header: 'Total',
+          cell: ({ row }) => {
+            if (row.depth !== 0) return null
+            const total = row.original.subRows.reduce((sum, e) => sum + e.amount, 0)
+            return formatNumber(total, 2)
+          },
+        },
+        {
+          id: 'amount',
+          header: 'Amount',
+          cell: ({ row }) => {
+            if (!row.depth) return null
+            const expense = row.original as ExpenseRow
+            const profile = profiles.find((p) => p.id === expense.profileId)
+            return (
+              <div className="flex gap-2 items-center">
+                <select
+                  className="border px-1 text-foreground"
+                  value={expense.account}
+                  onChange={(e) => updateExpense(expense, { account: e.target.value })}
+                >
+                  {profile?.bankAccounts.map((a) => (
+                    <option key={a} value={a}>
+                      {a}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="number"
+                  className="w-24 border px-1"
+                  value={expense.amount}
+                  onChange={(e) => updateExpense(expense, { amount: parseFloat(e.target.value) })}
+                />
+              </div>
+            )
+          },
+        },
+        {
+          id: 'description',
+          header: 'Description',
+          cell: ({ row }) => {
+            if (!row.depth) return null
+            const expense = row.original as ExpenseRow
+            return (
+              <input
+                type="text"
+                className="w-full border px-1"
+                value={expense.description}
+                onChange={(e) => updateExpense(expense, { description: e.target.value })}
+              />
+            )
+          },
+        },
+      ]
+    },
+    [allAccounts, profiles],
+  )
+
+  const table = useReactTable({
+    data: profiles,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getSubRows: (row) => row.subRows,
+    state: { expanded },
+    onExpandedChange: setExpanded,
+  })
+
+  return (
+    <EditableTable
+      table={table}
+      renderRowAction={(row) =>
+        row.depth === 0 ? (
+          <Button size="sm" onClick={() => addExpense(row.original.id)}>
+            Add Expense
+          </Button>
+        ) : null
+      }
+    />
+  )
+}

--- a/client/src/hooks/useBillPayments.ts
+++ b/client/src/hooks/useBillPayments.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { billPaymentApi } from '@/lib/api'
+import type { BillPayment } from '@/lib/dataSchema'
+
+export function useBillPayments() {
+  const [payments, setPayments] = useState<BillPayment[]>([])
+  const [deletedIds, setDeletedIds] = useState<string[]>([])
+
+  useEffect(() => {
+    billPaymentApi
+      .getAll()
+      .then((res) => setPayments(res.data as BillPayment[]))
+      .catch(() => {
+        /* ignore */
+      })
+  }, [])
+
+  const addPayment = (payment: BillPayment) => {
+    setPayments((p) => [...p, payment])
+  }
+
+  const updatePayment = (id: string, changes: Partial<BillPayment>) => {
+    setPayments((p) => p.map((bp) => (bp.id === id ? { ...bp, ...changes } : bp)))
+  }
+
+  const removePayment = (id: string) => {
+    setPayments((p) => p.filter((bp) => bp.id !== id))
+    setDeletedIds((d) => [...d, id])
+  }
+
+  return { payments, deletedIds, addPayment, updatePayment, removePayment }
+}

--- a/client/src/hooks/useProfiles.ts
+++ b/client/src/hooks/useProfiles.ts
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useState } from 'react'
+import { spendingProfileApi } from '@/lib/api'
+import type { SpendingProfile } from '@/lib/dataSchema'
+
+export interface ExpenseRow {
+  id: string
+  amount: number
+  description: string
+  account: string
+  profileId: string
+}
+
+export interface ProfileRow {
+  id: string
+  name: string
+  bankAccounts: string[]
+  subRows: ExpenseRow[]
+}
+
+export function useProfiles() {
+  const [profiles, setProfiles] = useState<ProfileRow[]>([])
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+
+  useEffect(() => {
+    spendingProfileApi
+      .getAll()
+      .then((res) => {
+        const data = (res.data as SpendingProfile[]).map((p) => ({
+          id: p.id,
+          name: p.name,
+          bankAccounts: p.bankAccounts,
+          subRows: [],
+        }))
+        setProfiles(data)
+      })
+      .catch(() => {
+        /* ignore */
+      })
+  }, [])
+
+  const addExpense = (profileId: string) => {
+    setProfiles((prev) =>
+      prev.map((p) =>
+        p.id === profileId
+          ? {
+              ...p,
+              subRows: [
+                ...p.subRows,
+                {
+                  id: Math.random().toString(),
+                  amount: 0,
+                  description: '',
+                  account: p.bankAccounts[0] || '',
+                  profileId,
+                },
+              ],
+            }
+          : p,
+      ),
+    )
+    setExpanded((e) => ({ ...e, [profileId]: true }))
+  }
+
+  const updateExpense = (expense: ExpenseRow, changes: Partial<ExpenseRow>) => {
+    setProfiles((prev) =>
+      prev.map((p) =>
+        p.subRows.includes(expense)
+          ? { ...p, subRows: p.subRows.map((s) => (s === expense ? { ...s, ...changes } : s)) }
+          : p,
+      ),
+    )
+  }
+
+  const allAccounts = useMemo(() => {
+    const set = new Set<string>()
+    profiles.forEach((p) => p.bankAccounts.forEach((a) => set.add(a)))
+    return Array.from(set)
+  }, [profiles])
+
+  return { profiles, expanded, setExpanded, addExpense, updateExpense, allAccounts }
+}

--- a/client/src/pages/BillingCyclePlannerPage.tsx
+++ b/client/src/pages/BillingCyclePlannerPage.tsx
@@ -1,59 +1,26 @@
-import { useEffect, useMemo, useState } from 'react'
-import { formatNumber } from 'accounting-js'
+import { useEffect, useState } from 'react'
+import dayjs from 'dayjs'
 import {
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  getExpandedRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
-import {
-  spendingProfileApi,
   billOptimizerApi,
   billingCycleApi,
   creditCardApi,
   bankAccountApi,
   expenseApi,
-  billPaymentApi,
 } from '@/lib/api'
-import type {
-  SpendingProfile,
-  BillingCycle,
-  Card,
-  BankAccount,
-} from '@/lib/dataSchema'
-import dayjs from 'dayjs'
+import type { BillingCycle, Card, BankAccount } from '@/lib/dataSchema'
 import { Button } from '@/components/ui/button'
 import Modal from '@/components/Modal'
 import { DialogClose } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-
-interface ExpenseRow {
-  id: string
-  amount: number
-  description: string
-  account: string
-  profileId: string
-}
-
-interface ProfileRow {
-  id: string
-  name: string
-  bankAccounts: string[]
-  subRows: ExpenseRow[]
-}
+import ProfileSection from '@/components/ProfileSection'
+import BillPaymentSection from '@/components/BillPaymentSection'
+import { useProfiles } from '@/hooks/useProfiles'
 
 export default function BillingCyclePlannerPage() {
-  const [profiles, setProfiles] = useState<ProfileRow[]>([])
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const {
+    profiles,
+  } = useProfiles()
+
   const [saving, setSaving] = useState(false)
   const [suggestions, setSuggestions] = useState<any[]>([])
   const [currentCycle, setCurrentCycle] = useState<BillingCycle | null>(null)
@@ -64,23 +31,7 @@ export default function BillingCyclePlannerPage() {
   const [labelInput, setLabelInput] = useState('')
   const [monthInput, setMonthInput] = useState(dayjs().format('MMMM').toUpperCase())
 
-  // load profiles
   useEffect(() => {
-    spendingProfileApi
-      .getAll()
-      .then((res) => {
-        const data = (res.data as SpendingProfile[]).map((p) => ({
-          id: p.id,
-          name: p.name,
-          bankAccounts: p.bankAccounts,
-          subRows: [],
-        }))
-        setProfiles(data)
-      })
-      .catch(() => {
-        /* ignore */
-      })
-
     billingCycleApi
       .getAll()
       .then((res) => {
@@ -122,7 +73,6 @@ export default function BillingCyclePlannerPage() {
       })
   }, [])
 
-  // auto save every 15s
   useEffect(() => {
     const id = setInterval(() => {
       handleSave()
@@ -178,8 +128,6 @@ export default function BillingCyclePlannerPage() {
         setCurrentCycle(cycle)
         setLabelInput(cycle.label)
         setMonthInput(cycle.month)
-        setProfiles([])
-        setExpanded({})
         setCreateOpen(false)
       })
       .catch(() => {
@@ -218,199 +166,6 @@ export default function BillingCyclePlannerPage() {
     if (cycles.some((c) => c.id !== currentCycle.id && c.month === val)) return
     updateCycle({ label: labelInput, month: val })
   }
-
-  const addExpense = (profileId: string) => {
-    setProfiles((prev) =>
-      prev.map((p) =>
-        p.id === profileId
-          ? {
-              ...p,
-              subRows: [
-                ...p.subRows,
-                {
-                  id: Math.random().toString(),
-                  amount: 0,
-                  description: '',
-                  account: p.bankAccounts[0] || '',
-                  profileId,
-                },
-              ],
-            }
-          : p,
-      ),
-    )
-    setExpanded((e) => ({ ...e, [profileId]: true }))
-  }
-
-  const allAccounts = useMemo(
-    () => {
-      const set = new Set<string>()
-      profiles.forEach((p) => {
-        p.bankAccounts.forEach((a) => set.add(a))
-      })
-      return Array.from(set)
-    },
-    [profiles],
-  )
-
-  const columns = useMemo<ColumnDef<ProfileRow>[]>(
-    () => {
-      const accountCols: ColumnDef<ProfileRow>[] = allAccounts.map((acc) => ({
-        id: acc,
-        header: acc,
-        cell: ({ row }) => {
-          if (row.depth !== 0) return null
-          const total = row.original.subRows
-            .filter((e) => e.account === acc)
-            .reduce((sum, e) => sum + e.amount, 0)
-          return total ? formatNumber(total, 2) : ''
-        },
-      }))
-
-      return [
-        {
-          id: 'name',
-          header: 'Category',
-          cell: ({ row }) => {
-            const isExpanded = row.getIsExpanded()
-            return (
-              <div className="flex items-center gap-2">
-                {row.getCanExpand() && (
-                  <button
-                    type="button"
-                    onClick={row.getToggleExpandedHandler()}
-                    className="font-mono"
-                  >
-                    {isExpanded ? '-' : '+'}
-                  </button>
-                )}
-                {row.depth === 0 && (
-                  <span className="font-semibold text-foreground">
-                    {(row.original as ProfileRow).name}
-                  </span>
-                )}
-              </div>
-            )
-          },
-        },
-        ...accountCols,
-        {
-          id: 'total',
-          header: 'Total',
-          cell: ({ row }) => {
-            if (row.depth !== 0) return null
-            const total = row.original.subRows.reduce(
-              (sum, e) => sum + e.amount,
-              0,
-            )
-            return formatNumber(total, 2)
-          },
-        },
-        {
-          id: 'amount',
-          header: 'Amount',
-          cell: ({ row }) => {
-            if (!row.depth) return null
-            const expense = row.original as ExpenseRow
-            const profile = profiles.find((p) => p.id === expense.profileId)
-            return (
-              <div className="flex gap-2 items-center">
-                <select
-                  className="border px-1 text-foreground"
-                  value={expense.account}
-                  onChange={(e) => {
-                    const val = e.target.value
-                    setProfiles((prev) =>
-                      prev.map((p) => {
-                        if (p.subRows.includes(expense)) {
-                          return {
-                            ...p,
-                            subRows: p.subRows.map((s) =>
-                              s === expense ? { ...s, account: val } : s,
-                            ),
-                          }
-                        }
-                        return p
-                      }),
-                    )
-                  }}
-                >
-                  {profile?.bankAccounts.map((a) => (
-                    <option key={a} value={a}>
-                      {a}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  type="number"
-                  className="w-24 border px-1"
-                  value={expense.amount}
-                  onChange={(e) => {
-                    const val = parseFloat(e.target.value)
-                    setProfiles((prev) =>
-                      prev.map((p) => {
-                        if (p.subRows.includes(expense)) {
-                          return {
-                            ...p,
-                            subRows: p.subRows.map((s) =>
-                              s === expense ? { ...s, amount: val } : s,
-                            ),
-                          }
-                        }
-                        return p
-                      }),
-                    )
-                  }}
-                />
-              </div>
-            )
-          },
-        },
-        {
-          id: 'description',
-          header: 'Description',
-          cell: ({ row }) => {
-            if (!row.depth) return null
-            const expense = row.original as ExpenseRow
-            return (
-              <input
-                type="text"
-                className="w-full border px-1"
-                value={expense.description}
-                onChange={(e) => {
-                  const val = e.target.value
-                  setProfiles((prev) =>
-                    prev.map((p) => {
-                      if (p.subRows.includes(expense)) {
-                        return {
-                          ...p,
-                          subRows: p.subRows.map((s) =>
-                            s === expense ? { ...s, description: val } : s,
-                          ),
-                        }
-                      }
-                      return p
-                    }),
-                  )
-                }}
-              />
-            )
-          },
-        },
-      ]
-    },
-    [allAccounts, profiles],
-  )
-
-  const table = useReactTable({
-    data: profiles,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    getExpandedRowModel: getExpandedRowModel(),
-    getSubRows: (row) => row.subRows,
-    state: { expanded },
-    onExpandedChange: setExpanded,
-  })
 
   return (
     <div className="flex flex-col gap-6 max-w-6xl mx-auto">
@@ -466,43 +221,12 @@ export default function BillingCyclePlannerPage() {
           </div>
         </div>
       )}
-      <Table className="border text-left">
-        <TableHeader>
-          {table.getHeaderGroups().map((hg) => (
-            <TableRow key={hg.id}>
-              {hg.headers.map((h) => (
-                <TableHead key={h.id} className="text-foreground">
-                  {flexRender(h.column.columnDef.header, h.getContext())}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
-              {row.depth === 0 && (
-                <TableCell>
-                  <Button size="sm" onClick={() => addExpense(row.original.id)}>
-                    Add Expense
-                  </Button>
-                </TableCell>
-              )}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <ProfileSection />
       <div className="flex justify-end gap-2">
         <Button onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
         </Button>
       </div>
-
       <div>
         <h2 className="font-bold mt-6 mb-2 text-foreground">Payment Suggestions</h2>
         <ul className="list-disc pl-6 text-foreground">
@@ -511,7 +235,7 @@ export default function BillingCyclePlannerPage() {
           ))}
         </ul>
       </div>
-
+      <BillPaymentSection accounts={accounts} cards={cards} />
       <div className="flex justify-end mt-6">
         <Button
           variant="destructive"


### PR DESCRIPTION
## Summary
- add `useProfiles` and `useBillPayments` hooks
- create reusable `EditableTable`
- add `ProfileSection` and `BillPaymentSection` components
- refactor `BillingCyclePlannerPage` to use new hooks and components

## Testing
- `npm run lint` *(fails: cannot find modules)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b3c2fd6e88323a5be43c0835f81a7