### PR TITLE
Fix type imports and compile issues

### DIFF
--- a/client/src/components/BillPaymentSection.tsx
+++ b/client/src/components/BillPaymentSection.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from 'react'
 import dayjs from 'dayjs'
-import {
-  ColumnDef,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
+import type { ColumnDef } from '@tanstack/react-table'
+import { getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import EditableTable from './EditableTable'
 import { Button } from './ui/button'
 import { useBillPayments } from '@/hooks/useBillPayments'

--- a/client/src/components/EditableTable.tsx
+++ b/client/src/components/EditableTable.tsx
@@ -1,6 +1,7 @@
-import { flexRender, Row, Table as ReactTable } from '@tanstack/react-table'
+import { flexRender } from '@tanstack/react-table'
+import type { Row, Table as ReactTable } from '@tanstack/react-table'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table'
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 interface Props<T> {
   table: ReactTable<T>

--- a/client/src/components/ProfileSection.tsx
+++ b/client/src/components/ProfileSection.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from 'react'
 import { formatNumber } from 'accounting-js'
-import {
-  ColumnDef,
-  getCoreRowModel,
-  getExpandedRowModel,
-  useReactTable,
-} from '@tanstack/react-table'
+import type { ColumnDef } from '@tanstack/react-table'
+import { getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import EditableTable from './EditableTable'
 import { Button } from './ui/button'
-import { ProfileRow, ExpenseRow, useProfiles } from '@/hooks/useProfiles'
+import type { ProfileRow, ExpenseRow } from '@/hooks/useProfiles'
+import { useProfiles } from '@/hooks/useProfiles'
 
 export default function ProfileSection() {
   const { profiles, expanded, setExpanded, addExpense, updateExpense, allAccounts } = useProfiles()
@@ -23,7 +20,7 @@ export default function ProfileSection() {
           const total = row.original.subRows
             .filter((e) => e.account === acc)
             .reduce((sum, e) => sum + e.amount, 0)
-          return total ? formatNumber(total, 2) : ''
+          return total ? formatNumber(total, { precision: 2 }) : ''
         },
       }))
 
@@ -60,7 +57,7 @@ export default function ProfileSection() {
           cell: ({ row }) => {
             if (row.depth !== 0) return null
             const total = row.original.subRows.reduce((sum, e) => sum + e.amount, 0)
-            return formatNumber(total, 2)
+            return formatNumber(total, { precision: 2 })
           },
         },
         {
@@ -68,7 +65,7 @@ export default function ProfileSection() {
           header: 'Amount',
           cell: ({ row }) => {
             if (!row.depth) return null
-            const expense = row.original as ExpenseRow
+            const expense = row.original as unknown as ExpenseRow
             const profile = profiles.find((p) => p.id === expense.profileId)
             return (
               <div className="flex gap-2 items-center">
@@ -98,7 +95,7 @@ export default function ProfileSection() {
           header: 'Description',
           cell: ({ row }) => {
             if (!row.depth) return null
-            const expense = row.original as ExpenseRow
+            const expense = row.original as unknown as ExpenseRow
             return (
               <input
                 type="text"
@@ -119,9 +116,9 @@ export default function ProfileSection() {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getSubRows: (row) => row.subRows,
+    getSubRows: (row) => row.subRows as unknown as ProfileRow[],
     state: { expanded },
-    onExpandedChange: setExpanded,
+    onExpandedChange: setExpanded as any,
   })
 
   return (

--- a/client/src/hooks/useProfiles.ts
+++ b/client/src/hooks/useProfiles.ts
@@ -8,6 +8,8 @@ export interface ExpenseRow {
   description: string
   account: string
   profileId: string
+  serverId?: string
+  dirty?: boolean
 }
 
 export interface ProfileRow {
@@ -52,6 +54,7 @@ export function useProfiles() {
                   description: '',
                   account: p.bankAccounts[0] || '',
                   profileId,
+                  dirty: true,
                 },
               ],
             }
@@ -65,7 +68,12 @@ export function useProfiles() {
     setProfiles((prev) =>
       prev.map((p) =>
         p.subRows.includes(expense)
-          ? { ...p, subRows: p.subRows.map((s) => (s === expense ? { ...s, ...changes } : s)) }
+          ? {
+              ...p,
+              subRows: p.subRows.map((s) =>
+                s === expense ? { ...s, ...changes, dirty: true } : s,
+              ),
+            }
           : p,
       ),
     )
@@ -77,5 +85,5 @@ export function useProfiles() {
     return Array.from(set)
   }, [profiles])
 
-  return { profiles, expanded, setExpanded, addExpense, updateExpense, allAccounts }
+  return { profiles, setProfiles, expanded, setExpanded, addExpense, updateExpense, allAccounts }
 }

--- a/client/src/pages/BillingCyclePlannerPage.tsx
+++ b/client/src/pages/BillingCyclePlannerPage.tsx
@@ -6,6 +6,8 @@ import {
   creditCardApi,
   bankAccountApi,
   expenseApi,
+  spendingProfileApi,
+  billPaymentApi,
 } from '@/lib/api'
 import type { BillingCycle, Card, BankAccount } from '@/lib/dataSchema'
 import { Button } from '@/components/ui/button'
@@ -28,6 +30,7 @@ interface PaymentRow {
 export default function BillingCyclePlannerPage() {
   const {
     profiles,
+    setProfiles,
   } = useProfiles()
 
   const [saving, setSaving] = useState(false)
@@ -267,6 +270,13 @@ export default function BillingCyclePlannerPage() {
     if (!currentCycle) return
     if (cycles.some((c) => c.id !== currentCycle.id && c.month === val)) return
     updateCycle({ label: labelInput, month: val })
+  }
+
+  const removeProfile = (profile: ProfileRow) => {
+    spendingProfileApi.remove(profile.id).catch(() => {
+      /* ignore */
+    })
+    setProfiles((prev) => prev.filter((p) => p.id !== profile.id))
   }
 
   return (

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -147,7 +147,7 @@ export default function DashboardPage() {
               {unpaid.map((u) => (
                 <tr key={u.cardId} className="border-t">
                   <td className="p-2">{u.cardName}</td>
-                  <td className="p-2">{formatNumber(u.amount, 2)}</td>
+                  <td className="p-2">{formatNumber(u.amount, { precision: 2 })}</td>
                 </tr>
               ))}
             </tbody>
@@ -167,7 +167,7 @@ export default function DashboardPage() {
               {accountTotals.map((a) => (
                 <tr key={a.accountId} className="border-t">
                   <td className="p-2">{a.accountName}</td>
-                  <td className="p-2">{formatNumber(a.amount, 2)}</td>
+                  <td className="p-2">{formatNumber(a.amount, { precision: 2 })}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- update hooks to include serverId and dirty flags
- use type-only imports for react-table types
- update formatting calls for accounting-js Settings
- expose profile setters and add profile removal
- fix build with new types

## Testing
- `npm --prefix client run lint` *(fails: 25 errors)*
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_688c44dfc06483239fe108c28ddefeb2