### PR TITLE
Fix Liquibase seed data order

### DIFF
--- a/server/src/main/resources/db/changelog/db.changelog-testdata.xml
+++ b/server/src/main/resources/db/changelog/db.changelog-testdata.xml
@@ -40,6 +40,14 @@
             <column name="is_default" valueBoolean="false"/>
             <column name="default_card_id" value="44444444-4444-4444-4444-444444444444"/>
         </insert>
+        <!-- Billing cycle with the payment -->
+        <insert tableName="billing_cycles">
+            <column name="id" value="77777777-7777-7777-7777-777777777777"/>
+            <column name="user_id" value="11111111-1111-1111-1111-111111111111"/>
+            <column name="label" value="January 2024"/>
+            <column name="month" value="JANUARY"/>
+            <column name="completed_date" valueDate="2024-01-31"/>
+        </insert>
 
         <!-- Sample expense paid with the demo card -->
         <insert tableName="expenses">
@@ -149,14 +157,6 @@
             <column name="billing_cycle_id" value="77777777-7777-7777-7777-777777777777"/>
         </insert>
 
-        <!-- Billing cycle with the payment -->
-        <insert tableName="billing_cycles">
-            <column name="id" value="77777777-7777-7777-7777-777777777777"/>
-            <column name="user_id" value="11111111-1111-1111-1111-111111111111"/>
-            <column name="label" value="January 2024"/>
-            <column name="month" value="JANUARY"/>
-            <column name="completed_date" valueDate="2024-01-31"/>
-        </insert>
 
 
         <!-- Expense summary record -->


### PR DESCRIPTION
## Summary
- load `billing_cycles` test data before inserting related rows

## Testing
- `./mvnw dependency:go-offline -q` *(fails: Failed to fetch)*
- `./mvnw test -q` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_688c600c4110832385188c0576edfcdb