### PR TITLE
Add Docker image artifacts to CI workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,11 +49,20 @@ jobs:
         run: |
           mv target/${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}.jar \
              target/${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}.jar
+      - name: Build Docker image
+        run: docker build -f Dockerfile.app -t ${{ steps.get_meta.outputs.artifactId }}:${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }} .
+      - name: Save Docker image
+        run: docker save ${{ steps.get_meta.outputs.artifactId }}:${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }} -o ${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}.tar
       - name: Upload JAR
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}
           path: server/target/${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}.jar
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}-docker-image
+          path: server/${{ steps.get_meta.outputs.artifactId }}-${{ steps.get_meta.outputs.version }}-${{ env.BUILD_TAG }}.tar
 
   liquibase-validate:
     name: Validate Liquibase Changelogs + Generate SQL

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -47,8 +47,17 @@ jobs:
         run: npm run build
       - name: Zip build output
         run: zip -r ${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}.zip dist/
+      - name: Build Docker image
+        run: docker build -t ${{ steps.get_frontend_meta.outputs.name }}:${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }} .
+      - name: Save Docker image
+        run: docker save ${{ steps.get_frontend_meta.outputs.name }}:${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }} -o ${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}.tar
       - name: Upload build ZIP
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}
           path: client/${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}.zip
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}-docker-image
+          path: client/${{ steps.get_frontend_meta.outputs.name }}-${{ steps.get_frontend_meta.outputs.version }}-${{ env.BUILD_TAG }}.tar

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:stable-alpine
+COPY dist /usr/share/nginx/html
+EXPOSE 80

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,47 @@
+# Deployment Steps
+
+This document explains how to deploy the artifacts produced by the CI workflows for both the backend and frontend.
+
+## Backend JAR (.jar)
+1. Download the backend JAR artifact from the CI run. The filename includes the project version and build tag.
+2. Copy the JAR to the target server where Java is installed.
+3. Ensure Java 21 or compatible is available on the server.
+4. Run the application:
+   ```bash
+   java -jar <artifact>.jar
+   ```
+5. Set any required environment variables (e.g., database credentials, JWT secret) before launching.
+
+## Frontend Build (.zip)
+1. Download the frontend ZIP artifact from the CI run.
+2. Unzip the archive to the directory served by your web server:
+   ```bash
+   unzip <artifact>.zip -d /var/www/app
+   ```
+3. Serve the extracted `dist/` directory using Nginx, Apache, or another static file host.
+
+## Backend Docker Image (.tar)
+1. Download the backend Docker image tarball from the CI run.
+2. Load the image into your local Docker registry:
+   ```bash
+   docker load -i <artifact>.tar
+   ```
+3. Run the container, mapping host port 8080 to the app's internal port 9000 and providing required environment variables:
+   ```bash
+   docker run -d -p 8080:9000 \
+     -e JWT_SECRET=<jwt-secret> \
+     -e GOOGLE_CLIENT_ID=<client-id> \
+     -e GOOGLE_CLIENT_SECRET=<client-secret> \
+     <image-name>
+   ```
+
+## Frontend Docker Image (.tar)
+1. Download the frontend Docker image tarball from the CI run.
+2. Load the image into Docker:
+   ```bash
+   docker load -i <artifact>.tar
+   ```
+3. Run the container, serving the app on port 80:
+   ```bash
+   docker run -d -p 80:80 <image-name>
+   ```

--- a/server/Dockerfile.app
+++ b/server/Dockerfile.app
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 9000
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
## Summary
- build and upload backend Docker image alongside the JAR artifact
- build and upload frontend Docker image alongside the ZIP artifact
- add Dockerfiles for backend runtime and frontend static assets
- document deployment steps for JAR, ZIP, and Docker image artifacts
- note required environment variables when running backend Docker image
- expose backend container port 9000 and document mapping `-p 8080:9000`

## Testing
- `./mvnw dependency:go-offline` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_688dde59d98083238edfb91bf8d7ca1f