### PR TITLE
feat: handle api load states

### DIFF
--- a/client/src/components/BillPaymentSection.tsx
+++ b/client/src/components/BillPaymentSection.tsx
@@ -13,7 +13,14 @@ interface Props {
 }
 
 export default function BillPaymentSection({ accounts, cards }: Props) {
-  const { payments, addPayment, removePayment, updatePayment } = useBillPayments()
+  const {
+    payments,
+    addPayment,
+    removePayment,
+    updatePayment,
+    loading,
+    error,
+  } = useBillPayments()
 
   const columns = useMemo<ColumnDef<BillPayment>[]>(
     () => [
@@ -88,14 +95,22 @@ export default function BillPaymentSection({ accounts, cards }: Props) {
 
   return (
     <div className="flex flex-col gap-2">
-      <EditableTable
-        table={table}
-        renderRowAction={(row) => (
-          <Button variant="destructive" size="sm" onClick={() => removePayment(row.original.id)}>
-            Delete
-          </Button>
-        )}
-      />
+      {loading ? (
+        <p>Loading payments...</p>
+      ) : error ? (
+        <p className="text-destructive">{error}</p>
+      ) : payments.length === 0 ? (
+        <p>No payments to show.</p>
+      ) : (
+        <EditableTable
+          table={table}
+          renderRowAction={(row) => (
+            <Button variant="destructive" size="sm" onClick={() => removePayment(row.original.id)}>
+              Delete
+            </Button>
+          )}
+        />
+      )}
       <div className="mt-2">
         <Button
           size="sm"

--- a/client/src/components/ManagementPage.tsx
+++ b/client/src/components/ManagementPage.tsx
@@ -39,7 +39,7 @@ export default function ManagementPage<T extends { id: string | number }>({
   defaultValues,
   renderForm,
 }: Props<T>) {
-  const { items, create, update, remove } = useEntityList<T>(endpoint)
+  const { items, create, update, remove, loading, error } = useEntityList<T>(endpoint)
   const [editing, setEditing] = useState<T | null>(null)
 
   const handleCreate = async (data: Partial<T>) => {
@@ -83,31 +83,47 @@ export default function ManagementPage<T extends { id: string | number }>({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.map((item) => (
-            <TableRow key={item.id}>
-              {columns.map((c) => (
-                <TableCell key={String(c.key)}>
-                  {c.render ? c.render(item) : (item as any)[c.key]}
-                </TableCell>
-              ))}
-              <TableCell className="space-x-2">
-                <ModalForm
-                  title="Edit"
-                  triggerLabel="Edit"
-                  formSchema={formSchema}
-                  defaultValues={{ ...defaultValues, ...item }}
-                  onOpen={() => setEditing(item)}
-                  onSubmit={(data) => handleUpdate(data as Partial<T>)}
-                  triggerClassName="mr-2"
-                >
-                  {(form) => renderForm(item, form)}
-                </ModalForm>
-                <Button variant="destructive" onClick={() => remove(item.id)}>
-                  Delete
-                </Button>
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={columns.length + 1}>Loading...</TableCell>
+            </TableRow>
+          ) : error ? (
+            <TableRow>
+              <TableCell colSpan={columns.length + 1} className="text-destructive">
+                {error}
               </TableCell>
             </TableRow>
-          ))}
+          ) : items.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={columns.length + 1}>Nothing to show.</TableCell>
+            </TableRow>
+          ) : (
+            items.map((item) => (
+              <TableRow key={item.id}>
+                {columns.map((c) => (
+                  <TableCell key={String(c.key)}>
+                    {c.render ? c.render(item) : (item as any)[c.key]}
+                  </TableCell>
+                ))}
+                <TableCell className="space-x-2">
+                  <ModalForm
+                    title="Edit"
+                    triggerLabel="Edit"
+                    formSchema={formSchema}
+                    defaultValues={{ ...defaultValues, ...item }}
+                    onOpen={() => setEditing(item)}
+                    onSubmit={(data) => handleUpdate(data as Partial<T>)}
+                    triggerClassName="mr-2"
+                  >
+                    {(form) => renderForm(item, form)}
+                  </ModalForm>
+                  <Button variant="destructive" onClick={() => remove(item.id)}>
+                    Delete
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
         </TableBody>
       </Table>
     </div>

--- a/client/src/components/ProfileSection.tsx
+++ b/client/src/components/ProfileSection.tsx
@@ -8,7 +8,16 @@ import type { ProfileRow, ExpenseRow } from '@/hooks/useProfiles'
 import { useProfiles } from '@/hooks/useProfiles'
 
 export default function ProfileSection() {
-  const { profiles, expanded, setExpanded, addExpense, updateExpense, allAccounts } = useProfiles()
+  const {
+    profiles,
+    expanded,
+    setExpanded,
+    addExpense,
+    updateExpense,
+    allAccounts,
+    loading,
+    error,
+  } = useProfiles()
 
   const columns = useMemo<ColumnDef<ProfileRow>[]>(
     () => {
@@ -120,6 +129,10 @@ export default function ProfileSection() {
     state: { expanded },
     onExpandedChange: setExpanded as any,
   })
+
+  if (loading) return <p>Loading profiles...</p>
+  if (error) return <p className="text-destructive">{error}</p>
+  if (!profiles.length) return <p>No profiles to show.</p>
 
   return (
     <EditableTable

--- a/client/src/hooks/useBillPayments.ts
+++ b/client/src/hooks/useBillPayments.ts
@@ -1,19 +1,24 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { billPaymentApi } from '@/lib/api'
 import type { BillPayment } from '@/lib/dataSchema'
+import { useFetch } from '@/hooks/useFetch'
 
 export function useBillPayments() {
   const [payments, setPayments] = useState<BillPayment[]>([])
   const [deletedIds, setDeletedIds] = useState<string[]>([])
 
+  const fetchPayments = useCallback(
+    () => billPaymentApi.getAll().then((res) => res.data as BillPayment[]),
+    [],
+  )
+
+  const { data, loading, error, reload } = useFetch(fetchPayments, {
+    errorMessage: 'Failed to load bill payments',
+  })
+
   useEffect(() => {
-    billPaymentApi
-      .getAll()
-      .then((res) => setPayments(res.data as BillPayment[]))
-      .catch(() => {
-        /* ignore */
-      })
-  }, [])
+    if (data) setPayments(data)
+  }, [data])
 
   const addPayment = (payment: BillPayment) => {
     setPayments((p) => [...p, payment])
@@ -28,5 +33,14 @@ export function useBillPayments() {
     setDeletedIds((d) => [...d, id])
   }
 
-  return { payments, deletedIds, addPayment, updatePayment, removePayment }
+  return {
+    payments,
+    deletedIds,
+    addPayment,
+    updatePayment,
+    removePayment,
+    loading,
+    error,
+    reload,
+  }
 }

--- a/client/src/hooks/useEntityList.ts
+++ b/client/src/hooks/useEntityList.ts
@@ -1,22 +1,22 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import api from '@/lib/api'
+import { useFetch } from '@/hooks/useFetch'
 
 export function useEntityList<T extends { id: string | number }>(endpoint: string) {
   const [items, setItems] = useState<T[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
-  const load = () => {
-    setLoading(true)
-    api.get<T[]>(endpoint)
-      .then(res => setItems(res.data))
-      .catch(() => setError('Failed to load data'))
-      .finally(() => setLoading(false))
-  }
+  const fetchItems = useCallback(
+    () => api.get<T[]>(endpoint).then((res) => res.data),
+    [endpoint],
+  )
+
+  const { data, loading, error, reload } = useFetch<T[]>(fetchItems, {
+    errorMessage: 'Failed to load data',
+  })
 
   useEffect(() => {
-    load()
-  }, [endpoint])
+    if (data) setItems(data)
+  }, [data])
 
   const create = async (payload: Partial<T>) => {
     const res = await api.post<T>(endpoint, payload)
@@ -33,5 +33,5 @@ export function useEntityList<T extends { id: string | number }>(endpoint: strin
     setItems(items => items.filter(it => it.id !== id))
   }
 
-  return { items, loading, error, create, update, remove, reload: load }
+  return { items, loading, error, create, update, remove, reload }
 }

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback, useEffect } from 'react'
+
+interface UseFetchOptions<T> {
+  immediate?: boolean
+  initialData?: T | null
+  errorMessage?: string
+}
+
+export function useFetch<T>(
+  fetcher: () => Promise<T>,
+  { immediate = true, initialData = null, errorMessage = 'Failed to load data' }: UseFetchOptions<T> = {},
+) {
+  const [data, setData] = useState<T | null>(initialData)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    return fetcher()
+      .then((res) => setData(res))
+      .catch(() => setError(errorMessage))
+      .finally(() => setLoading(false))
+  }, [fetcher, errorMessage])
+
+  useEffect(() => {
+    if (immediate) {
+      load()
+    }
+  }, [immediate, load])
+
+  return { data, loading, error, reload: load }
+}

--- a/client/src/hooks/usePaymentSuggestions.ts
+++ b/client/src/hooks/usePaymentSuggestions.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useCallback } from 'react'
 import api from '@/lib/api'
+import { useFetch } from '@/hooks/useFetch'
 
 export interface PaymentSuggestion {
   cardName: string
@@ -7,19 +8,22 @@ export interface PaymentSuggestion {
 }
 
 export function usePaymentSuggestions(enabled = true) {
-  const [suggestions, setSuggestions] = useState<PaymentSuggestion[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const fetchSuggestions = useCallback(
+    () => api.get('/bills/optimizer').then((res) => res.data),
+    [],
+  )
+
+  const { data, loading, error, reload } = useFetch<PaymentSuggestion[]>(
+    fetchSuggestions,
+    {
+      immediate: false,
+      errorMessage: 'Failed to load suggestions',
+    },
+  )
 
   useEffect(() => {
-    if (!enabled) return
-    setLoading(true)
-    api
-      .get('/bills/optimizer')
-      .then((res) => setSuggestions(res.data))
-      .catch(() => setError('Failed to load suggestions'))
-      .finally(() => setLoading(false))
-  }, [enabled])
+    if (enabled) reload()
+  }, [enabled, reload])
 
-  return { suggestions, loading, error }
+  return { suggestions: data ?? [], loading, error }
 }

--- a/client/src/hooks/useProfiles.ts
+++ b/client/src/hooks/useProfiles.ts
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
 import { spendingProfileApi } from '@/lib/api'
 import type { SpendingProfile } from '@/lib/dataSchema'
+import { useFetch } from '@/hooks/useFetch'
 
 export interface ExpenseRow {
   id: string
@@ -23,22 +24,26 @@ export function useProfiles() {
   const [profiles, setProfiles] = useState<ProfileRow[]>([])
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
-  useEffect(() => {
-    spendingProfileApi
-      .getAll()
-      .then((res) => {
-        const data = (res.data as SpendingProfile[]).map((p) => ({
+  const fetchProfiles = useCallback(
+    () =>
+      spendingProfileApi.getAll().then((res) =>
+        (res.data as SpendingProfile[]).map((p) => ({
           id: p.id,
           name: p.name,
           bankAccounts: p.bankAccounts,
           subRows: [],
-        }))
-        setProfiles(data)
-      })
-      .catch(() => {
-        /* ignore */
-      })
-  }, [])
+        })),
+      ),
+    [],
+  )
+
+  const { data, loading, error, reload } = useFetch<ProfileRow[]>(fetchProfiles, {
+    errorMessage: 'Failed to load spending profiles',
+  })
+
+  useEffect(() => {
+    if (data) setProfiles(data)
+  }, [data])
 
   const addExpense = (profileId: string) => {
     setProfiles((prev) =>
@@ -85,5 +90,16 @@ export function useProfiles() {
     return Array.from(set)
   }, [profiles])
 
-  return { profiles, setProfiles, expanded, setExpanded, addExpense, updateExpense, allAccounts }
+  return {
+    profiles,
+    setProfiles,
+    expanded,
+    setExpanded,
+    addExpense,
+    updateExpense,
+    allAccounts,
+    loading,
+    error,
+    reload,
+  }
 }

--- a/client/src/pages/BillingCyclePlannerPage.tsx
+++ b/client/src/pages/BillingCyclePlannerPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import {
-  billOptimizerApi,
   billingCycleApi,
   creditCardApi,
   bankAccountApi,
@@ -17,6 +16,7 @@ import { Input } from '@/components/ui/input'
 import ProfileSection from '@/components/ProfileSection'
 import BillPaymentSection from '@/components/BillPaymentSection'
 import { useProfiles, type ProfileRow } from '@/hooks/useProfiles'
+import { usePaymentSuggestions } from '@/hooks/usePaymentSuggestions'
 
 interface PaymentRow {
   id: string
@@ -37,7 +37,8 @@ export default function BillingCyclePlannerPage() {
   const [deletedExpenses, setDeletedExpenses] = useState<string[]>([])
   const [billPayments, setBillPayments] = useState<PaymentRow[]>([])
   const [deletedPayments, setDeletedPayments] = useState<string[]>([])
-  const [suggestions, setSuggestions] = useState<any[]>([])
+  const { suggestions, loading: suggestionsLoading, error: suggestionsError } =
+    usePaymentSuggestions()
   const [currentCycle, setCurrentCycle] = useState<BillingCycle | null>(null)
   const [cycles, setCycles] = useState<BillingCycle[]>([])
   const [accounts, setAccounts] = useState<BankAccount[]>([])
@@ -64,13 +65,6 @@ export default function BillingCyclePlannerPage() {
           setMonthInput(latest.month)
         }
       })
-      .catch(() => {
-        /* ignore */
-      })
-
-    billOptimizerApi
-      .getSuggestions()
-      .then((res) => setSuggestions(res.data))
       .catch(() => {
         /* ignore */
       })
@@ -340,11 +334,19 @@ export default function BillingCyclePlannerPage() {
       </div>
       <div>
         <h2 className="font-bold mt-6 mb-2 text-foreground">Payment Suggestions</h2>
-        <ul className="list-disc pl-6 text-foreground">
-          {suggestions.map((s, idx) => (
-            <li key={idx}>{JSON.stringify(s)}</li>
-          ))}
-        </ul>
+        {suggestionsLoading ? (
+          <p>Loading suggestions...</p>
+        ) : suggestionsError ? (
+          <p className="text-destructive">{suggestionsError}</p>
+        ) : suggestions.length === 0 ? (
+          <p>Nothing to show.</p>
+        ) : (
+          <ul className="list-disc pl-6 text-foreground">
+            {suggestions.map((s, idx) => (
+              <li key={idx}>{JSON.stringify(s)}</li>
+            ))}
+          </ul>
+        )}
       </div>
       <BillPaymentSection accounts={accounts} cards={cards} />
       <div className="flex justify-end mt-6">

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -49,6 +49,8 @@ export default function DashboardPage() {
   const [unpaid, setUnpaid] = useState<UnpaidPerCard[]>([])
   const [accountTotals, setAccountTotals] = useState<SpendPerAccount[]>([])
   const [cycleData, setCycleData] = useState<CycleChartDatum[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const load = async () => {
@@ -124,9 +126,10 @@ export default function DashboardPage() {
       setCycleData(cycleArr)
     }
 
-    load().catch(() => {
-      // noop
-    })
+    setLoading(true)
+    load()
+      .catch(() => setError('Failed to load dashboard data'))
+      .finally(() => setLoading(false))
   }, [])
 
   return (
@@ -144,12 +147,32 @@ export default function DashboardPage() {
               </tr>
             </thead>
             <tbody>
-              {unpaid.map((u) => (
-                <tr key={u.cardId} className="border-t">
-                  <td className="p-2">{u.cardName}</td>
-                  <td className="p-2">{formatNumber(u.amount, { precision: 2 })}</td>
+              {loading ? (
+                <tr>
+                  <td colSpan={2} className="p-2">
+                    Loading...
+                  </td>
                 </tr>
-              ))}
+              ) : error ? (
+                <tr>
+                  <td colSpan={2} className="p-2 text-destructive">
+                    {error}
+                  </td>
+                </tr>
+              ) : unpaid.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="p-2">
+                    Nothing to show.
+                  </td>
+                </tr>
+              ) : (
+                unpaid.map((u) => (
+                  <tr key={u.cardId} className="border-t">
+                    <td className="p-2">{u.cardName}</td>
+                    <td className="p-2">{formatNumber(u.amount, { precision: 2 })}</td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>
@@ -164,12 +187,32 @@ export default function DashboardPage() {
               </tr>
             </thead>
             <tbody>
-              {accountTotals.map((a) => (
-                <tr key={a.accountId} className="border-t">
-                  <td className="p-2">{a.accountName}</td>
-                  <td className="p-2">{formatNumber(a.amount, { precision: 2 })}</td>
+              {loading ? (
+                <tr>
+                  <td colSpan={2} className="p-2">
+                    Loading...
+                  </td>
                 </tr>
-              ))}
+              ) : error ? (
+                <tr>
+                  <td colSpan={2} className="p-2 text-destructive">
+                    {error}
+                  </td>
+                </tr>
+              ) : accountTotals.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="p-2">
+                    Nothing to show.
+                  </td>
+                </tr>
+              ) : (
+                accountTotals.map((a) => (
+                  <tr key={a.accountId} className="border-t">
+                    <td className="p-2">{a.accountName}</td>
+                    <td className="p-2">{formatNumber(a.amount, { precision: 2 })}</td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>
@@ -177,15 +220,23 @@ export default function DashboardPage() {
 
       <div className="w-full h-72">
         <h2 className="font-bold mb-2 text-foreground">Expenses vs Payments</h2>
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={cycleData} margin={{ top: 20, right: 30, bottom: 5, left: 0 }}>
-            <XAxis dataKey="label" />
-            <YAxis />
-            <Tooltip />
-            <Bar dataKey="expenses" stackId="total" fill="var(--chart-2)" name="Expenses" />
-            <Bar dataKey="payments" stackId="total" fill="var(--chart-1)" name="Paid" />
-          </BarChart>
-        </ResponsiveContainer>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-destructive">{error}</p>
+        ) : cycleData.length === 0 ? (
+          <p>Nothing to show.</p>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={cycleData} margin={{ top: 20, right: 30, bottom: 5, left: 0 }}>
+              <XAxis dataKey="label" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="expenses" stackId="total" fill="var(--chart-2)" name="Expenses" />
+              <Bar dataKey="payments" stackId="total" fill="var(--chart-1)" name="Paid" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- extract a reusable `useFetch` hook to centralize loading, error, and reload state
- refactor bill payments, profiles, entity list, and payment suggestion hooks to use `useFetch`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 24 errors, 2 warnings)
- `npm run build`
- `./mvnw test` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_688ec97bb618832394232d28e5aadd1e